### PR TITLE
Updated to the latest DocumentFormat.OpenXml and getting it from NuGet.

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -40,7 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net35\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -68,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="template.docx" />
   </ItemGroup>
   <ItemGroup>

--- a/Demo/packages.config
+++ b/Demo/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net35" />
+</packages>

--- a/Trunk/HtmlToOpenXml.csproj
+++ b/Trunk/HtmlToOpenXml.csproj
@@ -40,7 +40,9 @@
     <DocumentationFile>bin\Release\HtmlToOpenXml.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net35\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -100,6 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="HtmlToOpenXml.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\PredefinedStyles.resx">

--- a/Trunk/packages.config
+++ b/Trunk/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
This is necessary to support the latest version of DocumentFormat.OpenXml.
Could you also please update the NuGet package of html2openxml?
I am not sure if this is a breaking change, but I guess not, if the users of html2openxml also update there DocumentFormat.OpenXml (as the demo.csproj) in this solution.
Thankx, Harry
