### PR TITLE
Fix bug when font is set multiple times per html tag

### DIFF
--- a/Trunk/Collections/OpenXmlStyleCollectionBase.cs
+++ b/Trunk/Collections/OpenXmlStyleCollectionBase.cs
@@ -120,7 +120,8 @@ namespace NotesFor.HtmlToOpenXml
 			{
 				Dictionary<String, OpenXmlElement> knonwTags = new Dictionary<String, OpenXmlElement>();
 				for (int i = 0; i < elements.Count; i++)
-					knonwTags.Add(elements[i].LocalName, elements[i]);
+                        if (!knonwTags.ContainsKey(elements[i].LocalName))                        
+                            knonwTags.Add(elements[i].LocalName, elements[i]);                       
 
 				OpenXmlElement[] array;
 				foreach (TagsAtSameLevel tagOfSameLevel in enqueuedTags)


### PR DESCRIPTION
In some conditions, Html content can define font attributes in multiple ways simultaneously.

This fix ensure only the first one is used to avoid crash when merging FontRun tags.