### PR TITLE
Update to processing <blockquote> to check for additional style names

### DIFF
--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -86,22 +86,14 @@ namespace HtmlToOpenXml
 		{
 			CompleteCurrentParagraph(true);
 
-            string blockQuoteStyle = null;
-
             if (htmlStyles.DoesStyleExists("IntenseQuote"))
-                blockQuoteStyle = htmlStyles.GetStyle("IntenseQuote");
-            else if (htmlStyles.DoesStyleExists("Intense Quote"))
-                blockQuoteStyle = htmlStyles.GetStyle("Intense Quote");
-
-            if (string.IsNullOrEmpty(blockQuoteStyle))
             {
-                // if the style was not yet defined, we force the indentation
-                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new Indentation() { Left = "708" });
+                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle("IntenseQuote") });
             }
             else
             {
-                // for nested paragraphs:
-                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = blockQuoteStyle });
+                // if the style was not yet defined, we force the indentation
+                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new Indentation() { Left = "708" });
             }
 
 			// TODO: handle attribute cite and create footnote

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -86,12 +86,23 @@ namespace HtmlToOpenXml
 		{
 			CompleteCurrentParagraph(true);
 
-			// for nested paragraphs:
-			htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle("IntenseQuote") });
+            string blockQuoteStyle = null;
 
-			// if the style was not yet defined, we force the indentation
-			if (!htmlStyles.DoesStyleExists("IntenseQuote"))
-				htmlStyles.Paragraph.BeginTag(en.CurrentTag, new Indentation() { Left = "708" });
+            if (htmlStyles.DoesStyleExists("IntenseQuote"))
+                blockQuoteStyle = htmlStyles.GetStyle("IntenseQuote");
+            else if (htmlStyles.DoesStyleExists("Intense Quote"))
+                blockQuoteStyle = htmlStyles.GetStyle("Intense Quote");
+
+            if (string.IsNullOrEmpty(blockQuoteStyle))
+            {
+                // if the style was not yet defined, we force the indentation
+                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new Indentation() { Left = "708" });
+            }
+            else
+            {
+                // for nested paragraphs:
+                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle("IntenseQuote") });
+            }
 
 			// TODO: handle attribute cite and create footnote
 		}

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -101,7 +101,7 @@ namespace HtmlToOpenXml
             else
             {
                 // for nested paragraphs:
-                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle("IntenseQuote") });
+                htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = blockQuoteStyle });
             }
 
 			// TODO: handle attribute cite and create footnote


### PR DESCRIPTION
This should fix #22 and possibly #21.  I adjusted the code to check for both "IntenseQuote" and "Intense Quote" styles.  If either of those is found then the `htmlStyles.Paragraph.BeginTag` method is called with a Paragraph Style ID, otherwise, the Indentation is used.