### PR TITLE
Fixed an issue where styles are being removed

### DIFF
--- a/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
+++ b/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
@@ -194,7 +194,7 @@ namespace HtmlToOpenXml
                         openXmlElement = firstChild;
                     }
 #if FEATURE_REFLECTION
-                    else if (!type.IsInstanceOfType(tag))
+                    else if (!type.IsInstanceOfType(firstChild))
 #else
                     else if (!type.GetTypeInfo().IsAssignableFrom(tag.GetType().GetTypeInfo()))
 #endif


### PR DESCRIPTION
When ProcessCommonAttributes  is being called and contains containerStylesAttributes during the execution of BeginTag it can cause the firstChild style (in this example "w:tcW") to be removed.

Example screenshot

![image](https://user-images.githubusercontent.com/4850116/55061708-aec3b280-5074-11e9-8af2-c4b635ae5c04.png)
