### PR TITLE
Support latest OpenXml release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 solution: HtmlToOpenXml.sln
-dotnet: 1.1.13
+dotnet: 3.1.301
 mono: none
 install:
   - dotnet restore HtmlToOpenXml.sln

--- a/examples/Demo/Demo.csproj
+++ b/examples/Demo/Demo.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;net40;net46;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-
-  <ItemGroup>
+  <ItemGroup> 
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Demo/Program.cs
+++ b/examples/Demo/Program.cs
@@ -21,8 +21,11 @@ namespace Demo
             {
                 // Uncomment and comment the second using() to open an existing template document
                 // instead of creating it from scratch.
+                using (var buffer = ResourceHelper.GetStream("Resources.template.docx"))
+                {
+                    buffer.CopyTo(generatedDocument);
+                }
 
-                using (var buffer = ResourceHelper.GetStream("Resources.template.docx")) buffer.CopyToAsync(generatedDocument);
                 generatedDocument.Position = 0L;
                 using (WordprocessingDocument package = WordprocessingDocument.Open(generatedDocument, true))
                 //using (WordprocessingDocument package = WordprocessingDocument.Create(generatedDocument, WordprocessingDocumentType.Document))

--- a/examples/Demo/packages.config
+++ b/examples/Demo/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net35" />
-</packages>

--- a/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
+++ b/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
@@ -18,25 +18,16 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace HtmlToOpenXml
 {
-	using TagsAtSameLevel = System.ArraySegment<DocumentFormat.OpenXml.OpenXmlElement>;
+    using TagsAtSameLevel = System.ArraySegment<DocumentFormat.OpenXml.OpenXmlElement>;
 
     /// <summary>
     /// Defines the styles to apply on OpenXml elements.
     /// </summary>
     abstract class OpenXmlStyleCollectionBase
     {
-        /// <summary>
-        /// Handler to retrieves the insert order of a child inside its parent element.
-        /// </summary>
-        /// <param name="child">The child to look up.</param>
-        /// <returns>The sequence order where to insert the child.</returns>
-        protected delegate int GetSequenceNumberHandler(OpenXmlElement child);
-
-
         /// <summary>Holds the tags to apply to the current OpenXml element.</summary>
         /// <remarks>The key contains the name of the tag, the values contains a list of queued attributes of the same tag.</remarks>
-        protected Dictionary<String, Stack<TagsAtSameLevel>> tags;
-
+        protected readonly Dictionary<String, Stack<TagsAtSameLevel>> tags;
 
         protected OpenXmlStyleCollectionBase()
         {
@@ -166,90 +157,21 @@ namespace HtmlToOpenXml
 
         #region SetProperties
 
+        private static readonly MethodInfo _setMethod =
+#if FEATURE_REFLECTION
+            typeof(OpenXmlCompositeElement).GetMethod("SetElement", BindingFlags.Instance | BindingFlags.NonPublic);
+#else
+            typeof(OpenXmlCompositeElement).GetTypeInfo().DeclaredMethods.First(m => m.Name == "SetElement");
+#endif
+
         /// <summary>
         /// Insert a style element inside a RunProperties, taking care of the correct sequence order as defined in the ECMA Standard.
         /// </summary>
         /// <param name="containerProperties">A RunProperties or ParagraphProperties wherein the tag will be inserted.</param>
         /// <param name="tag">The style to apply to the run.</param>
         protected void SetProperties(OpenXmlCompositeElement containerProperties, OpenXmlElement tag)
-        {
-            // This implementation is largely inspired by DocumentFormat.OpenXml.OpenXmlCompositeElement.SetElement which is internal.
-
-            int tagOrder = GetTagOrder(tag);
-
-            OpenXmlElement firstChild = containerProperties.FirstChild;
-            OpenXmlElement openXmlElement = null;
-            Type type = tag.GetType();
-
-            while (firstChild != null)
-            {
-                bool isKnownElement = (!(firstChild is OpenXmlUnknownElement) && !(firstChild is OpenXmlMiscNode));
-                if (isKnownElement)
-                {
-                    int num = GetTagOrder(firstChild);
-
-                    if (num != tagOrder)
-                    {
-                        if (num > tagOrder) break;
-                        openXmlElement = firstChild;
-                    }
-#if FEATURE_REFLECTION
-                    else if (!type.IsInstanceOfType(firstChild))
-#else
-                    else if (!type.GetTypeInfo().IsAssignableFrom(tag.GetType().GetTypeInfo()))
-#endif
-                    {
-                        openXmlElement = firstChild;
-                    }
-                    else
-                    {
-                        openXmlElement = firstChild.PreviousSibling();
-                        containerProperties.RemoveChild<OpenXmlElement>(firstChild);
-                        break;
-                    }
-                }
-
-                firstChild = firstChild.NextSibling();
-            }
-
-            if (tag != null)
-                containerProperties.InsertAfter(tag, openXmlElement);
-        }
-
-#endregion
-
-        #region GetTagOrder
-
-        protected static GetSequenceNumberHandler CreateTagOrderDelegate<T>()
-            where T : OpenXmlCompositeElement, new()
-        {
-            // I don't want to hard-code the sequence number of the child elements of a RunProperties.
-            // I prefer relying on the OpenXml API and use a bit Reflection.
-#if FEATURE_REFLECTION
-            var mi = typeof(OpenXmlCompositeElement)
-                .GetMethod("GetSequenceNumber", BindingFlags.Instance | BindingFlags.NonPublic);
-
-            // We use a dummy new RunProperties instance
-            // Create a delegate to speed up the invocation to the GetSequenceNumber method
-            return (GetSequenceNumberHandler)
-                 Delegate.CreateDelegate(typeof(GetSequenceNumberHandler), new RunProperties(), mi, true);
-#else
-            var mi = typeof(OpenXmlCompositeElement).GetTypeInfo()
-                .DeclaredMethods.First(m => m.Name == "GetSequenceNumber");
-
-            // We use a dummy new RunProperties instance
-            // Create a delegate to speed up the invocation to the GetSequenceNumber method
-            return (GetSequenceNumberHandler) mi.CreateDelegate(typeof(GetSequenceNumberHandler), new T());
-#endif
-        }
+            => _setMethod.MakeGenericMethod(tag.GetType()).Invoke(containerProperties, new[] { tag });
 
         #endregion
-
-        /// <summary>
-        /// Resolve the element order of the children of RunProperties or ParagraphProperties.
-        /// </summary>
-        /// <param name="element">The child item to look up.</param>
-        /// <returns>Returns the order of the child.</returns>
-        protected abstract int GetTagOrder(OpenXmlElement element);
     }
 }

--- a/src/Html2OpenXml/Collections/ParagraphStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/ParagraphStyleCollection.cs
@@ -22,9 +22,7 @@ namespace HtmlToOpenXml
 
 	sealed class ParagraphStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private HtmlDocumentStyle documentStyle;
-        private readonly static GetSequenceNumberHandler getTagOrderHandler = CreateTagOrderDelegate<ParagraphProperties>();
-
+		private readonly HtmlDocumentStyle documentStyle;
 
         internal ParagraphStyleCollection(HtmlDocumentStyle documentStyle)
 		{
@@ -223,15 +221,6 @@ namespace HtmlToOpenXml
 
 			return newParagraph;
 		}
-
-        #endregion
-
-        #region GetTagOrder
-
-        protected override int GetTagOrder(OpenXmlElement element)
-        {
-            return (int) getTagOrderHandler.DynamicInvoke(element);
-        }
 
         #endregion
 

--- a/src/Html2OpenXml/Collections/RunStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/RunStyleCollection.cs
@@ -22,9 +22,7 @@ namespace HtmlToOpenXml
 
 	sealed class RunStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private HtmlDocumentStyle documentStyle;
-		private readonly static GetSequenceNumberHandler getTagOrderHandler = CreateTagOrderDelegate<RunProperties>();
-
+		private readonly HtmlDocumentStyle documentStyle;
 
 		internal RunStyleCollection(HtmlDocumentStyle documentStyle)
 		{
@@ -121,15 +119,6 @@ namespace HtmlToOpenXml
 					styleAttributes.Add(new FontSize() { Val = (font.Size.ValueInPoint * 2).ToString(CultureInfo.InvariantCulture) });
 			}
 		}
-
-        #endregion
-
-        #region GetTagOrder
-
-        protected override int GetTagOrder(OpenXmlElement element)
-        {
-            return (int) getTagOrderHandler.DynamicInvoke(element);
-        }
 
         #endregion
 

--- a/src/Html2OpenXml/Collections/TableStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/TableStyleCollection.cs
@@ -21,10 +21,8 @@ namespace HtmlToOpenXml
 
 	sealed class TableStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private ParagraphStyleCollection paragraphStyle;
-		private HtmlDocumentStyle documentStyle;
-        private readonly static GetSequenceNumberHandler getTagOrderHandler = CreateTagOrderDelegate<TableProperties>();
-
+		private readonly ParagraphStyleCollection paragraphStyle;
+		private readonly HtmlDocumentStyle documentStyle;
 
         internal TableStyleCollection(HtmlDocumentStyle documentStyle)
 		{
@@ -138,15 +136,6 @@ namespace HtmlToOpenXml
 
 			// Process general run styles
 			documentStyle.Runs.ProcessCommonAttributes(en, runStyleAttributes);
-		}
-
-		#endregion
-
-		#region GetTagOrder
-
-		protected override int GetTagOrder(OpenXmlElement element)
-		{
-			return (int) getTagOrderHandler.DynamicInvoke(element);
 		}
 
 		#endregion

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -71,7 +71,7 @@ You can see release note here: https://github.com/onizet/html2openxml/releases
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/src/Html2OpenXml/packages.config
+++ b/src/Html2OpenXml/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net35" />
-</packages>

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Html2OpenXml\HtmlToOpenXml.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
+	  <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Html2OpenXml\HtmlToOpenXml.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Html2OpenXml\HtmlToOpenXml.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
-	  <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netcoreapp2.1</TargetFrameworks>
+	  <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+	  <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Html2OpenXml\HtmlToOpenXml.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/test/HtmlToOpenXml.Tests/ImageFormats/ImageHeaderTests.cs
+++ b/test/HtmlToOpenXml.Tests/ImageFormats/ImageHeaderTests.cs
@@ -55,8 +55,6 @@ namespace HtmlToOpenXml.Tests
         [Test]
         public void ReadSizeEmf()
         {
-            Assert.Ignore("Test currently failing. Returning 100 but expecting 252");
-
             using (var imageStream = ResourceHelper.GetStream("Resources.html2openxml.emf"))
             {
                 Size size = ImageHeader.GetDimensions(imageStream);

--- a/test/HtmlToOpenXml.Tests/ImageFormats/ImageHeaderTests.cs
+++ b/test/HtmlToOpenXml.Tests/ImageFormats/ImageHeaderTests.cs
@@ -55,6 +55,8 @@ namespace HtmlToOpenXml.Tests
         [Test]
         public void ReadSizeEmf()
         {
+            Assert.Ignore("Test currently failing. Returning 100 but expecting 252");
+
             using (var imageStream = ResourceHelper.GetStream("Resources.html2openxml.emf"))
             {
                 Size size = ImageHeader.GetDimensions(imageStream);


### PR DESCRIPTION
Looks like there was some internal usage of APIs that are no longer supported. This change updates to latest OpenXml build (v2.11.0), although it is still using an internal method. 

Related: https://github.com/OfficeDev/Open-XML-SDK/issues/492

Fixes #70