### PR TITLE
Add support for numbered headings

### DIFF
--- a/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
@@ -12,6 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -23,7 +25,7 @@ namespace HtmlToOpenXml
 		private int nextInstanceID, levelDepth;
         private int maxlevelDepth = 0;
         private bool firstItem;
-		private Dictionary<String, Int32> knonwAbsNumIds;
+		private Dictionary<String, Int32> knownAbsNumIds;
 		private Stack<KeyValuePair<Int32, int>> numInstances;
 
 
@@ -66,7 +68,7 @@ namespace HtmlToOpenXml
 			// This minimal numbering definition has been inspired by the documentation OfficeXMLMarkupExplained_en.docx
 			// http://www.microsoft.com/downloads/details.aspx?FamilyID=6f264d0b-23e8-43fe-9f82-9ab627e5eaa3&displaylang=en
 
-			DocumentFormat.OpenXml.OpenXmlElement[] absNumChildren = new [] {
+			AbstractNum[] absNumChildren = new [] {
 				//8 kinds of abstractnum + 1 multi-level.
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
@@ -79,7 +81,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef },
+				) { AbstractNumberId = absNumIdRef, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "decimal" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -90,7 +92,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 1 },
+				) { AbstractNumberId = absNumIdRef + 1, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "disc" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -101,7 +103,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 2 },
+				) { AbstractNumberId = absNumIdRef + 2, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "square" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -112,7 +114,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 3 },
+				) { AbstractNumberId = absNumIdRef + 3, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "circle" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -124,7 +126,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 4 },
+				) { AbstractNumberId = absNumIdRef + 4, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "upper-alpha" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -136,7 +138,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 5 },
+				) { AbstractNumberId = absNumIdRef + 5, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "lower-alpha" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -148,7 +150,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 6 },
+				) { AbstractNumberId = absNumIdRef + 6, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "upper-roman" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -160,33 +162,80 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 7 }
+				) { AbstractNumberId = absNumIdRef + 7, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "lower-roman" } },
+				// decimal-title-multi
+				// WARNING: only use this for headings
+				new AbstractNum(
+					new MultiLevelType() { Val = MultiLevelValues.Multilevel },
+					new Level {
+						StartNumberingValue = new StartNumberingValue() { Val = 1 },
+						NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Decimal },
+						LevelIndex = 0,
+						LevelText = new LevelText() { Val = "%1." }
+					},
+					new Level {
+						StartNumberingValue = new StartNumberingValue() { Val = 1 },
+						NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Decimal },
+						LevelIndex = 1,
+						LevelText = new LevelText() { Val = "%1.%2." }
+					},
+					new Level {
+						StartNumberingValue = new StartNumberingValue() { Val = 1 },
+						NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Decimal },
+						LevelIndex = 2,
+						LevelText = new LevelText() { Val = "%1.%2.%3." }
+					}
+				) { AbstractNumberId = absNumIdRef + 8, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "decimal-title-multi" } }
 			};
 
-			// this is not documented but MS Word needs that all the AbstractNum are stored consecutively.
-			// Otherwise, it will apply the "NoList" style to the existing ListInstances.
-			// This is the reason why I insert all the items after the last AbstractNum.
-			int lastAbsNumIndex = 0;
-			if (absNumIdRef > 0)
+			// Check if we have already initialized our abstract nums
+			// if that is the case, we should not add them again.
+			// This supports a use-case where the HtmlConverter is called multiple times
+			// on document generation, and needs to continue existing lists
+			bool addNewAbstractNums = false;
+			IEnumerable<AbstractNum> existingAbstractNums = numberingPart.Numbering.ChildElements.ToList().Where(e => e != null && e is AbstractNum).Cast<AbstractNum>();
+
+			if (existingAbstractNums.Count() >= absNumChildren.Length) // means we might have added our own already
 			{
-				lastAbsNumIndex = numberingPart.Numbering.ChildElements.Count-1;
-				for (; lastAbsNumIndex >= 0; lastAbsNumIndex--)
+				foreach (var abstractNum in absNumChildren)
 				{
-					if(numberingPart.Numbering.ChildElements[lastAbsNumIndex] is AbstractNum)
-						break;
+					// Check if we can find this in the existing document
+					addNewAbstractNums = addNewAbstractNums 
+						|| !existingAbstractNums.Any(a => a.AbstractNumDefinitionName != null && a.AbstractNumDefinitionName.Val.Value == abstractNum.AbstractNumDefinitionName.Val.Value);
 				}
+			} else {
+				addNewAbstractNums = true;
 			}
 
-			for (int i = 0; i < absNumChildren.Length; i++)
-				numberingPart.Numbering.InsertAt(absNumChildren[i], i + lastAbsNumIndex);
+			if (addNewAbstractNums)
+			{
+				// this is not documented but MS Word needs that all the AbstractNum are stored consecutively.
+				// Otherwise, it will apply the "NoList" style to the existing ListInstances.
+				// This is the reason why I insert all the items after the last AbstractNum.
+				int lastAbsNumIndex = 0;
+				if (absNumIdRef > 0)
+				{
+					lastAbsNumIndex = numberingPart.Numbering.ChildElements.Count-1;
+					for (; lastAbsNumIndex >= 0; lastAbsNumIndex--)
+					{
+						if(numberingPart.Numbering.ChildElements[lastAbsNumIndex] is AbstractNum)
+							break;
+					}
+				}
 
-			// initializes the lookup
-			knonwAbsNumIds = new Dictionary<String, Int32>() {
-				{ "disc", absNumIdRef+1 }, { "square", absNumIdRef+2 }, { "circle" , absNumIdRef+3 },
-				{ "upper-alpha", absNumIdRef+4 }, { "lower-alpha", absNumIdRef+5 },
-				{ "upper-roman", absNumIdRef+6 }, { "lower-roman", absNumIdRef+7 },
-				{ "decimal", absNumIdRef }
-			};
+				for (int i = 0; i < absNumChildren.Length; i++)
+					numberingPart.Numbering.InsertAt(absNumChildren[i], i + lastAbsNumIndex);
+
+				knownAbsNumIds = absNumChildren
+					.Cast<AbstractNum>()
+					.ToDictionary(a => a.AbstractNumDefinitionName.Val.Value, a => a.AbstractNumberId.Value);
+			} 
+			else
+			{
+				knownAbsNumIds = existingAbstractNums.ToList()
+					.Where(a => a.AbstractNumDefinitionName != null && a.AbstractNumDefinitionName.Val != null)
+					.ToDictionary(a => a.AbstractNumDefinitionName.Val.Value, a => a.AbstractNumberId.Value);
+			}
 
 			// compute the next list instance ID seed. We start at 1 because 0 has a special meaning: 
 			// The w:numId can contain a value of 0, which is a special value that indicates that numbering was removed
@@ -208,19 +257,33 @@ namespace HtmlToOpenXml
 
 		public void BeginList(HtmlEnumerator en)
 		{
-			int prevAbsNumId = numInstances.Peek().Value;
-			var absNumId = -1;
-
 			// lookup for a predefined list style in the template collection
 			String type = en.StyleAttributes["list-style-type"];
 			bool orderedList = en.CurrentTag.Equals("<ol>", StringComparison.OrdinalIgnoreCase);
-			if (type == null || !knonwAbsNumIds.TryGetValue(type.ToLowerInvariant(), out absNumId))
-			{
-				if (orderedList)
-					absNumId = knonwAbsNumIds["decimal"];
-				else
-					absNumId = knonwAbsNumIds["disc"];
-			}
+
+			CreateList(type, orderedList);
+		}
+
+		#endregion
+
+		#region EndList
+
+		public void EndList()
+		{
+			if (levelDepth > 0)
+				numInstances.Pop();  // decrement for nested list
+			levelDepth--;
+			firstItem = true;
+		}
+
+		#endregion
+
+		#region CreateList
+
+		public int CreateList(String type, bool orderedList, int numberOfLevels = 1)
+		{
+			int absNumId = GetAbsNumIdFromType(type, orderedList);
+			int prevAbsNumId = numInstances.Peek().Value;
 
 			firstItem = true;
 			levelDepth++;
@@ -244,31 +307,52 @@ namespace HtmlToOpenXml
                 {
                     currentInstanceId = ++nextInstanceID;
                     Numbering numbering = mainPart.NumberingDefinitionsPart.Numbering;
+
+					List<OpenXmlElement> elements = new List<OpenXmlElement>();
+
+					elements.Add(new AbstractNumId() { Val = absNumId });
+
+					for (int i = 0; i < numberOfLevels; i++)
+					{
+						elements.Add(new LevelOverride(
+							new StartOverrideNumberingValue() {
+								Val = 1
+							})
+							{
+								LevelIndex = i
+							});
+					}
+
                     numbering.Append(
                         new NumberingInstance(
-                            new AbstractNumId() { Val = absNumId },
-                            new LevelOverride(
-                                new StartOverrideNumberingValue() { Val = 1 }
-                            )
-                            { LevelIndex = 0, }
+                            elements
                         )
                         { NumberID = currentInstanceId });
                 }
             }
 
 			numInstances.Push(new KeyValuePair<int, int>(currentInstanceId, absNumId));
+
+			return currentInstanceId;
 		}
 
 		#endregion
 
-		#region EndList
+		#region GetAbsNumIdFromType
 
-		public void EndList()
+		public int GetAbsNumIdFromType(String type, bool orderedList)
 		{
-			if (levelDepth > 0)
-				numInstances.Pop();  // decrement for nested list
-			levelDepth--;
-			firstItem = true;
+			int absNumId;
+
+			if (type == null || !knownAbsNumIds.TryGetValue(type.ToLowerInvariant(), out absNumId))
+			{
+				if (orderedList)
+					absNumId = knownAbsNumIds["decimal"];
+				else
+					absNumId = knownAbsNumIds["disc"];
+			}
+
+			return absNumId;
 		}
 
 		#endregion

--- a/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
@@ -268,19 +268,29 @@ namespace HtmlToOpenXml
 
 		#region EndList
 
-		public void EndList()
+		public void EndList(bool popInstances = true)
 		{
-			if (levelDepth > 0)
+			if (levelDepth > 0 && popInstances)
 				numInstances.Pop();  // decrement for nested list
+
 			levelDepth--;
 			firstItem = true;
 		}
 
 		#endregion
 
+		#region SetLevelDepth
+
+		public void SetLevelDepth(int newLevelDepth)
+		{
+			levelDepth = newLevelDepth;
+		}
+
+		#endregion
+
 		#region CreateList
 
-		public int CreateList(String type, bool orderedList, int numberOfLevels = 1)
+		public int CreateList(String type, bool orderedList)
 		{
 			int absNumId = GetAbsNumIdFromType(type, orderedList);
 			int prevAbsNumId = numInstances.Peek().Value;
@@ -308,24 +318,13 @@ namespace HtmlToOpenXml
                     currentInstanceId = ++nextInstanceID;
                     Numbering numbering = mainPart.NumberingDefinitionsPart.Numbering;
 
-					List<OpenXmlElement> elements = new List<OpenXmlElement>();
-
-					elements.Add(new AbstractNumId() { Val = absNumId });
-
-					for (int i = 0; i < numberOfLevels; i++)
-					{
-						elements.Add(new LevelOverride(
-							new StartOverrideNumberingValue() {
-								Val = 1
-							})
-							{
-								LevelIndex = i
-							});
-					}
-
                     numbering.Append(
                         new NumberingInstance(
-                            elements
+                            new AbstractNumId() { Val = absNumId },
+							new LevelOverride(
+								new StartOverrideNumberingValue() { Val = 1 }
+							)
+							{ LevelIndex = 0 }
                         )
                         { NumberID = currentInstanceId });
                 }

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -297,7 +297,7 @@ namespace HtmlToOpenXml
 						.FirstOrDefault(n => MatchNumberingInstance(n, requiredNumberId)) as NumberingInstance;
 					
 					if (existingTitleNumbering == null)
-						titleListId = htmlStyles.NumberingList.CreateList("decimal-title-multi", true, 3);
+						titleListId = htmlStyles.NumberingList.CreateList("decimal-title-multi", true);
 					else
 						titleListId = existingTitleNumbering.NumberID.Value;
 				}
@@ -307,11 +307,14 @@ namespace HtmlToOpenXml
 					new NumberingLevelReference(){ Val = (indentLevel - 1) }, // indenting starts at 0
                     new NumberingId(){ Val = titleListId }
 				));
+
+				htmlStyles.NumberingList.EndList(false);
+				htmlStyles.NumberingList.SetLevelDepth(0);
 			}
 
 			htmlStyles.Paragraph.ApplyTags(p);
 			htmlStyles.Paragraph.EndTag("<h" + level + ">");
-
+			
 			this.elements.Clear();
 			AddParagraph(p);
 			AddParagraph(currentParagraph = htmlStyles.Paragraph.NewParagraph());

--- a/src/Html2OpenXml/HtmlConverter.cs
+++ b/src/Html2OpenXml/HtmlConverter.cs
@@ -56,6 +56,7 @@ namespace HtmlToOpenXml
 		private HtmlDocumentStyle htmlStyles;
 		private uint drawingObjId, imageObjId;
 		private Uri baseImageUri;
+		private int titleListId;
 
 
 

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>HtmlToOpenXml</AssemblyName>
     <RootNamespace>HtmlToOpenXml</RootNamespace>
-    <PackageId>HtmlToOpenXml.dll</PackageId>
+    <PackageId>Intron.HtmlToOpenXml.dll</PackageId>
     <Version>2.1.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <Copyright>Copyright 2009-2020</Copyright>

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>HtmlToOpenXml</AssemblyName>
     <RootNamespace>HtmlToOpenXml</RootNamespace>
-    <PackageId>Intron.HtmlToOpenXml.dll</PackageId>
+    <PackageId>HtmlToOpenXml.dll</PackageId>
     <Version>2.1.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <Copyright>Copyright 2009-2020</Copyright>


### PR DESCRIPTION
I've added support for numbered headings + cleaned up the code a little.

It now supports headings starting with a number in the format `[number]. [title]` till 3 levels deep: `[number].[number].[number]. [title]`. It will automatically make these headings numbered (the specific numbers in the headings are ignored though).

Next to that I added a check for `AbstractNum`s. If you call HtmlConverter multiple times on a Word document, it will add the `AbstractNum`s to the doc every time. Now it will check if the `AbstractNum`s we add are already defined, and if so, won't add them again. 

P.S.: it's my first pull request ever, so if things aren't right let me know :) 