### PR TITLE
Add support for numbered headings

### DIFF
--- a/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
@@ -12,6 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -19,13 +21,15 @@ namespace HtmlToOpenXml
 {
 	sealed class NumberingListStyleCollection
 	{
+		public const string HEADING_NUMBERING_NAME = "decimal-heading-multi";
+
 		private MainDocumentPart mainPart;
 		private int nextInstanceID, levelDepth;
         private int maxlevelDepth = 0;
         private bool firstItem;
-		private Dictionary<String, Int32> knonwAbsNumIds;
+		private Dictionary<String, Int32> knownAbsNumIds;
 		private Stack<KeyValuePair<Int32, int>> numInstances;
-
+		private int headingNumberingId;
 
 		public NumberingListStyleCollection(MainDocumentPart mainPart)
 		{
@@ -66,7 +70,7 @@ namespace HtmlToOpenXml
 			// This minimal numbering definition has been inspired by the documentation OfficeXMLMarkupExplained_en.docx
 			// http://www.microsoft.com/downloads/details.aspx?FamilyID=6f264d0b-23e8-43fe-9f82-9ab627e5eaa3&displaylang=en
 
-			DocumentFormat.OpenXml.OpenXmlElement[] absNumChildren = new [] {
+			AbstractNum[] absNumChildren = new [] {
 				//8 kinds of abstractnum + 1 multi-level.
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
@@ -79,7 +83,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef },
+				) { AbstractNumberId = absNumIdRef, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "decimal" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -90,7 +94,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 1 },
+				) { AbstractNumberId = absNumIdRef + 1, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "disc" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -101,7 +105,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 2 },
+				) { AbstractNumberId = absNumIdRef + 2, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "square" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -112,7 +116,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 3 },
+				) { AbstractNumberId = absNumIdRef + 3, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "circle" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -124,7 +128,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 4 },
+				) { AbstractNumberId = absNumIdRef + 4, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "upper-alpha" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -136,7 +140,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 5 },
+				) { AbstractNumberId = absNumIdRef + 5, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "lower-alpha" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -148,7 +152,7 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 6 },
+				) { AbstractNumberId = absNumIdRef + 6, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "upper-roman" } },
 				new AbstractNum(
 					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
 					new Level {
@@ -160,33 +164,67 @@ namespace HtmlToOpenXml
 							Indentation = new Indentation() { Left = "420", Hanging = "360" }
 						}
 					}
-				) { AbstractNumberId = absNumIdRef + 7 }
+				) { AbstractNumberId = absNumIdRef + 7, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = "lower-roman" } },
+				// decimal-heading-multi
+				// WARNING: only use this for headings
+				new AbstractNum(
+					new MultiLevelType() { Val = MultiLevelValues.SingleLevel },
+					new Level {
+						StartNumberingValue = new StartNumberingValue() { Val = 1 },
+						NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Decimal },
+						LevelIndex = 0,
+						LevelText = new LevelText() { Val = "%1." }
+					}
+				) { AbstractNumberId = absNumIdRef + 8, AbstractNumDefinitionName = new AbstractNumDefinitionName() { Val = HEADING_NUMBERING_NAME } }
 			};
 
-			// this is not documented but MS Word needs that all the AbstractNum are stored consecutively.
-			// Otherwise, it will apply the "NoList" style to the existing ListInstances.
-			// This is the reason why I insert all the items after the last AbstractNum.
-			int lastAbsNumIndex = 0;
-			if (absNumIdRef > 0)
+			// Check if we have already initialized our abstract nums
+			// if that is the case, we should not add them again.
+			// This supports a use-case where the HtmlConverter is called multiple times
+			// on document generation, and needs to continue existing lists
+			bool addNewAbstractNums = false;
+			IEnumerable<AbstractNum> existingAbstractNums = numberingPart.Numbering.ChildElements.Where(e => e != null && e is AbstractNum).Cast<AbstractNum>();
+
+			if (existingAbstractNums.Count() >= absNumChildren.Length) // means we might have added our own already
 			{
-				lastAbsNumIndex = numberingPart.Numbering.ChildElements.Count-1;
-				for (; lastAbsNumIndex >= 0; lastAbsNumIndex--)
+				foreach (var abstractNum in absNumChildren)
 				{
-					if(numberingPart.Numbering.ChildElements[lastAbsNumIndex] is AbstractNum)
-						break;
+					// Check if we can find this in the existing document
+					addNewAbstractNums = addNewAbstractNums 
+						|| !existingAbstractNums.Any(a => a.AbstractNumDefinitionName != null && a.AbstractNumDefinitionName.Val.Value == abstractNum.AbstractNumDefinitionName.Val.Value);
 				}
+			} else {
+				addNewAbstractNums = true;
 			}
 
-			for (int i = 0; i < absNumChildren.Length; i++)
-				numberingPart.Numbering.InsertAt(absNumChildren[i], i + lastAbsNumIndex);
+			if (addNewAbstractNums)
+			{
+				// this is not documented but MS Word needs that all the AbstractNum are stored consecutively.
+				// Otherwise, it will apply the "NoList" style to the existing ListInstances.
+				// This is the reason why I insert all the items after the last AbstractNum.
+				int lastAbsNumIndex = 0;
+				if (absNumIdRef > 0)
+				{
+					lastAbsNumIndex = numberingPart.Numbering.ChildElements.Count-1;
+					for (; lastAbsNumIndex >= 0; lastAbsNumIndex--)
+					{
+						if(numberingPart.Numbering.ChildElements[lastAbsNumIndex] is AbstractNum)
+							break;
+					}
+				}
 
-			// initializes the lookup
-			knonwAbsNumIds = new Dictionary<String, Int32>() {
-				{ "disc", absNumIdRef+1 }, { "square", absNumIdRef+2 }, { "circle" , absNumIdRef+3 },
-				{ "upper-alpha", absNumIdRef+4 }, { "lower-alpha", absNumIdRef+5 },
-				{ "upper-roman", absNumIdRef+6 }, { "lower-roman", absNumIdRef+7 },
-				{ "decimal", absNumIdRef }
-			};
+				for (int i = 0; i < absNumChildren.Length; i++)
+					numberingPart.Numbering.InsertAt(absNumChildren[i], i + lastAbsNumIndex);
+
+				knownAbsNumIds = absNumChildren
+					.ToDictionary(a => a.AbstractNumDefinitionName.Val.Value, a => a.AbstractNumberId.Value);
+			} 
+			else
+			{
+				knownAbsNumIds = existingAbstractNums
+					.Where(a => a.AbstractNumDefinitionName != null && a.AbstractNumDefinitionName.Val != null)
+					.ToDictionary(a => a.AbstractNumDefinitionName.Val.Value, a => a.AbstractNumberId.Value);
+			}
 
 			// compute the next list instance ID seed. We start at 1 because 0 has a special meaning: 
 			// The w:numId can contain a value of 0, which is a special value that indicates that numbering was removed
@@ -208,19 +246,82 @@ namespace HtmlToOpenXml
 
 		public void BeginList(HtmlEnumerator en)
 		{
-			int prevAbsNumId = numInstances.Peek().Value;
-			var absNumId = -1;
-
 			// lookup for a predefined list style in the template collection
 			String type = en.StyleAttributes["list-style-type"];
 			bool orderedList = en.CurrentTag.Equals("<ol>", StringComparison.OrdinalIgnoreCase);
-			if (type == null || !knonwAbsNumIds.TryGetValue(type.ToLowerInvariant(), out absNumId))
+
+			CreateList(type, orderedList);
+		}
+
+		#endregion
+
+		#region EndList
+
+		public void EndList(bool popInstances = true)
+		{
+			if (levelDepth > 0 && popInstances)
+				numInstances.Pop();  // decrement for nested list
+
+			levelDepth--;
+			firstItem = true;
+		}
+
+		#endregion
+
+		#region SetLevelDepth
+
+		public void SetLevelDepth(int newLevelDepth)
+		{
+			levelDepth = newLevelDepth;
+		}
+
+		#endregion
+
+		#region Headings
+
+		public int GetHeadingNumberingId()
+		{
+			if (headingNumberingId == default(int))
 			{
-				if (orderedList)
-					absNumId = knonwAbsNumIds["decimal"];
-				else
-					absNumId = knonwAbsNumIds["disc"];
+				int absNumberId = GetAbsNumIdFromType(HEADING_NUMBERING_NAME, true);
+
+				NumberingInstance existingTitleNumbering = mainPart.NumberingDefinitionsPart.Numbering
+					.Elements<NumberingInstance>()
+					.FirstOrDefault(n => n != null && n.AbstractNumId.Val == absNumberId);
+				
+				if (existingTitleNumbering != null)
+					headingNumberingId = existingTitleNumbering.NumberID.Value;
+				else 
+				{
+					headingNumberingId = CreateList(HEADING_NUMBERING_NAME, true);
+					EnsureMultilevel(absNumberId, true);
+				}
 			}
+				
+			return headingNumberingId;
+		}
+
+		public void ApplyNumberingToHeadingParagraph(Paragraph p, int indentLevel)
+		{
+			// Apply numbering to paragraph
+			p.InsertInProperties(prop => prop.NumberingProperties = new NumberingProperties(
+				new NumberingLevelReference(){ Val = (indentLevel - 1) }, // indenting starts at 0
+				new NumberingId(){ Val = GetHeadingNumberingId() }
+			));
+
+			// Make sure we reset everything for upcoming lists
+			EndList(false);
+			SetLevelDepth(0);
+		}
+
+		#endregion
+
+		#region CreateList
+
+		public int CreateList(String type, bool orderedList)
+		{
+			int absNumId = GetAbsNumIdFromType(type, orderedList);
+			int prevAbsNumId = numInstances.Peek().Value;
 
 			firstItem = true;
 			levelDepth++;
@@ -244,31 +345,41 @@ namespace HtmlToOpenXml
                 {
                     currentInstanceId = ++nextInstanceID;
                     Numbering numbering = mainPart.NumberingDefinitionsPart.Numbering;
+
                     numbering.Append(
                         new NumberingInstance(
                             new AbstractNumId() { Val = absNumId },
-                            new LevelOverride(
-                                new StartOverrideNumberingValue() { Val = 1 }
-                            )
-                            { LevelIndex = 0, }
+							new LevelOverride(
+								new StartOverrideNumberingValue() { Val = 1 }
+							)
+							{ LevelIndex = 0 }
                         )
                         { NumberID = currentInstanceId });
                 }
             }
 
 			numInstances.Push(new KeyValuePair<int, int>(currentInstanceId, absNumId));
+
+			return currentInstanceId;
 		}
 
 		#endregion
 
-		#region EndList
+		#region GetAbsNumIdFromType
 
-		public void EndList()
+		public int GetAbsNumIdFromType(String type, bool orderedList)
 		{
-			if (levelDepth > 0)
-				numInstances.Pop();  // decrement for nested list
-			levelDepth--;
-			firstItem = true;
+			int absNumId;
+
+			if (type == null || !knownAbsNumIds.TryGetValue(type.ToLowerInvariant(), out absNumId))
+			{
+				if (orderedList)
+					absNumId = knownAbsNumIds["decimal"];
+				else
+					absNumId = knownAbsNumIds["disc"];
+			}
+
+			return absNumId;
 		}
 
 		#endregion
@@ -326,18 +437,9 @@ namespace HtmlToOpenXml
 		/// <summary>
 		/// Find a specified AbstractNum by its ID and update its definition to make it multi-level.
 		/// </summary>
-		private void EnsureMultilevel(int absNumId)
+		private void EnsureMultilevel(int absNumId, bool cascading = false)
 		{
-			AbstractNum absNumMultilevel = null;
-			foreach (AbstractNum absNum in mainPart.NumberingDefinitionsPart.Numbering.Elements<AbstractNum>())
-			{
-				if (absNum.AbstractNumberId == absNumId)
-				{
-					absNumMultilevel = absNum;
-					break;
-				}
-			}
-
+			AbstractNum absNumMultilevel = mainPart.NumberingDefinitionsPart.Numbering.Elements<AbstractNum>().SingleOrDefault(a => a.AbstractNumberId.Value == absNumId);
 
 			if (absNumMultilevel != null && absNumMultilevel.MultiLevelType.Val == MultiLevelValues.SingleLevel)
 			{
@@ -347,15 +449,31 @@ namespace HtmlToOpenXml
 				// skip the first level, starts to 2
 				for (int i = 2; i < 10; i++)
 				{
-					absNumMultilevel.Append(new Level {
+					Level level = new Level {
 						StartNumberingValue = new StartNumberingValue() { Val = 1 },
 						NumberingFormat = new NumberingFormat() { Val = level1.NumberingFormat.Val },
-						LevelIndex = i - 1,
-						LevelText = new LevelText() { Val = "%" + i + "." },
-						PreviousParagraphProperties = new PreviousParagraphProperties {
-							Indentation = new Indentation() { Left = (720 * i).ToString(CultureInfo.InvariantCulture), Hanging = "360" }
-						}
-					});
+						LevelIndex = i - 1
+					};
+
+					if (cascading) 
+					{
+						// if we're cascading, that means we don't want any identation 
+						// + our leveltext should contain the previous levels as well
+						StringBuilder lvlText = new StringBuilder();
+
+						for (int lvlIndex = 1; lvlIndex <= i; lvlIndex++)
+							lvlText.AppendFormat("%{0}.", lvlIndex);
+
+						level.LevelText = new LevelText() { Val = lvlText.ToString() };
+					} else {
+						level.LevelText = new LevelText() { Val = "%" + i + "." };
+						level.PreviousParagraphProperties = 
+							new PreviousParagraphProperties {
+								Indentation = new Indentation() { Left = (720 * i).ToString(CultureInfo.InvariantCulture), Hanging = "360" }
+							};
+					}
+
+					absNumMultilevel.Append(level);
 				}
 			}
 		}


### PR DESCRIPTION
This is a updated version of PR #76 

Changes compared to previous PR:
- Regex changed, it now only captures the numeric group at the beginning of the string
- Supports up to 8 levels deep (as it uses `EnsureMultilevel` now)
- Moved the numbering logic from `HtmlConvert.ProcessTag` to `NumberingListStyleCollection`
- Fix some LINQ formatting
- Name of the heading list is now a compile-time constant

I've tested this with a document which uses diverse numbered headings and other (un)ordered lists, I couldn't spot any problems so far.