### PR TITLE
Fix SetProperties to work with the latest OpenXML version

### DIFF
--- a/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
+++ b/src/Html2OpenXml/Collections/OpenXmlStyleCollectionBase.cs
@@ -162,7 +162,13 @@ namespace HtmlToOpenXml
         /// <param name="containerProperties">A RunProperties or ParagraphProperties wherein the tag will be inserted.</param>
         /// <param name="tag">The style to apply to the run.</param>
         protected void SetProperties(OpenXmlCompositeElement containerProperties, OpenXmlElement tag)
-            => _setMethod.MakeGenericMethod(tag.GetType()).Invoke(containerProperties, new[] { tag });
+        {
+            MethodInfo methodInfo = _setMethod;
+            if (methodInfo.IsGenericMethodDefinition)
+                _setMethod.MakeGenericMethod(tag.GetType()).Invoke(containerProperties, new[] { tag });
+            else
+                _setMethod.Invoke(containerProperties, new[] { tag });
+        }
 
         #endregion
     }


### PR DESCRIPTION
Compiling html2openxml with the current _master_ branch of OpenXML fails running Unit Tests with this error:

System.InvalidOperationException : Boolean SetElement(DocumentFormat.OpenXml.OpenXmlElement) is not a GenericMethodDefinition. MakeGenericMethod may only be called on a method for which MethodBase.IsGenericMethodDefinition is true.

Stack:
    RuntimeMethodInfo.MakeGenericMethod(Type[] methodInstantiation)
    OpenXmlStyleCollectionBase.SetProperties(OpenXmlCompositeElement containerProperties, OpenXmlElement tag) line 165
    ParagraphStyleCollection.ApplyTags(OpenXmlCompositeElement paragraph) line 47
    HtmlConverter.CompleteCurrentParagraph(Boolean createNew) line 701
    HtmlConverter.ProcessBlockQuote(HtmlEnumerator en) line 110
    HtmlConverter.ProcessHtmlChunks(HtmlEnumerator en, String endTag) line 206
    HtmlConverter.Parse(String html) line 110
    AbbrTests.ParseWithLinks(String html, String expectedUri) line 44