### PR TITLE
Allow end users to define default styles

### DIFF
--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -49,12 +49,12 @@ namespace HtmlToOpenXml
 				if (this.AcronymPosition == AcronymPosition.PageEnd)
 				{
 					reference = new FootnoteReference() { Id = AddFootnoteReference(title) };
-					runStyle = "FootnoteReference";
+					runStyle = htmlStyles.DefaultStyles.FootnoteReferenceStyle;
 				}
 				else
 				{
 					reference = new EndnoteReference() { Id = AddEndnoteReference(title) };
-					runStyle = "EndnoteReference";
+					runStyle = htmlStyles.DefaultStyles.EndnoteReferenceStyle;
 				}
 
 				Run run;
@@ -78,7 +78,7 @@ namespace HtmlToOpenXml
 			string tagName = en.CurrentTag;
 			string cite = en.Attributes["cite"];
 
-			htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle("IntenseQuote") });
+			htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.IntenseQuoteStyle) });
 
 			AlternateProcessHtmlChunks(en, en.ClosingCurrentTag);
 
@@ -90,12 +90,12 @@ namespace HtmlToOpenXml
 				if (this.AcronymPosition == AcronymPosition.PageEnd)
 				{
 					reference = new FootnoteReference() { Id = AddFootnoteReference(cite) };
-					runStyle = "FootnoteReference";
+					runStyle = htmlStyles.DefaultStyles.FootnoteReferenceStyle;
 				}
 				else
 				{
 					reference = new EndnoteReference() { Id = AddEndnoteReference(cite) };
-					runStyle = "EndnoteReference";
+					runStyle = htmlStyles.DefaultStyles.EndnoteReferenceStyle;
 				}
 
 				Run run;
@@ -163,7 +163,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessCite(HtmlEnumerator en)
 		{
-			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle("Quote", StyleValues.Character) });
+			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
 		}
 
 		#endregion
@@ -274,7 +274,7 @@ namespace HtmlToOpenXml
 
 			Paragraph p = new Paragraph(elements);
 			p.InsertInProperties(prop =>
-				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("Heading" + level, StyleValues.Paragraph) });
+				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.HeadingStyle + level, StyleValues.Paragraph) });
 
 			// Check if the line starts with a number format (1., 1.1., 1.1.1.)
 			// If it does, make sure we make the heading a numbered item
@@ -388,7 +388,7 @@ namespace HtmlToOpenXml
 
 			currentParagraph.Append(
 					new ParagraphProperties {
-						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("Caption", StyleValues.Paragraph) },
+						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) },
 						KeepNext = new KeepNext()
 					},
 					new Run(
@@ -488,7 +488,7 @@ namespace HtmlToOpenXml
 			// Save the new paragraph reference to support nested numbering list.
 			Paragraph p = currentParagraph;
 			currentParagraph.InsertInProperties(prop => {
-				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("ListParagraph", StyleValues.Paragraph) };
+				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.ListParagraphStyle, StyleValues.Paragraph) };
 				prop.Indentation = level < 2? null : new Indentation() { Left = (level * 780).ToString(CultureInfo.InvariantCulture) };
 				prop.NumberingProperties = new NumberingProperties {
 					NumberingLevelReference = new NumberingLevelReference() { Val = level - 1 },
@@ -587,7 +587,7 @@ namespace HtmlToOpenXml
 				if (run != null && !run.HasChild<Drawing>())
 				{
 					run.InsertInProperties(prop =>
-						prop.RunStyle = new RunStyle() { Val = htmlStyles.GetStyle("Hyperlink", StyleValues.Character) });
+						prop.RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.HyperlinkStyle, StyleValues.Character) });
 					break;
 				}
 			}
@@ -657,7 +657,7 @@ namespace HtmlToOpenXml
             {
                 Table currentTable = new Table(
                     new TableProperties (
-                        new TableStyle() { Val = htmlStyles.GetStyle("TableGrid", StyleValues.Table) },
+                        new TableStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.PreTableStyle, StyleValues.Table) },
                         new TableWidth() { Type = TableWidthUnitValues.Pct, Width = "5000" } // 100% * 50
 					),
                     new TableGrid(
@@ -718,7 +718,7 @@ namespace HtmlToOpenXml
 			htmlStyles.Runs.ApplyTags(run);
 			elements.Add(run);
 
-			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle("Quote", StyleValues.Character) });
+			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
 		}
 
 		#endregion
@@ -778,7 +778,7 @@ namespace HtmlToOpenXml
 		private void ProcessTable(HtmlEnumerator en)
 		{
 			TableProperties properties = new TableProperties(
-				new TableStyle() { Val = htmlStyles.GetStyle("TableGrid", StyleValues.Table) }
+				new TableStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.TableStyle, StyleValues.Table) }
 			);
 			Table currentTable = new Table(properties);
 
@@ -807,7 +807,7 @@ namespace HtmlToOpenXml
 
 				// If the border has been specified, we display the Table Grid style which display
 				// its grid lines. Otherwise the default table style hides the grid lines.
-				if (handleBorders && properties.TableStyle.Val != "TableGrid")
+				if (handleBorders && properties.TableStyle.Val != htmlStyles.DefaultStyles.TableStyle)
 				{
 					uint borderSize = border.Value > 1? (uint) new Unit(UnitMetric.Pixel, border.Value).ValueInDxa : 1;
 					properties.TableBorders = new TableBorders() {
@@ -962,7 +962,7 @@ namespace HtmlToOpenXml
 
 			var legend = new Paragraph(
 					new ParagraphProperties {
-						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("Caption", StyleValues.Paragraph) }
+						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) }
 					},
 					new Run(
 						new FieldChar() { FieldCharType = FieldCharValues.Begin }),

--- a/src/Html2OpenXml/HtmlConverter.cs
+++ b/src/Html2OpenXml/HtmlConverter.cs
@@ -94,10 +94,10 @@ namespace HtmlToOpenXml
 
 			// Start a new processing
 			paragraphs.Add(currentParagraph = htmlStyles.Paragraph.NewParagraph());
-			if (htmlStyles.DefaultParagraphStyle != null)
+			if (htmlStyles.DefaultStyles.ParagraphStyle != null)
 			{
 				currentParagraph.ParagraphProperties = new ParagraphProperties {
-					ParagraphStyleId = new ParagraphStyleId { Val = htmlStyles.DefaultParagraphStyle }
+					ParagraphStyleId = new ParagraphStyleId { Val = htmlStyles.DefaultStyles.ParagraphStyle }
 				};
 			}
 
@@ -323,11 +323,11 @@ namespace HtmlToOpenXml
 				new Footnote(
 					p = new Paragraph(
 						new ParagraphProperties {
-							ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("FootnoteText", StyleValues.Paragraph) }
+							ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.FootnoteTextStyle, StyleValues.Paragraph) }
 						},
 						markerRun = new Run(
 							new RunProperties {
-								RunStyle = new RunStyle() { Val = htmlStyles.GetStyle("FootnoteReference", StyleValues.Character) }
+								RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.FootnoteReferenceStyle, StyleValues.Character) }
 							},
 							new FootnoteReferenceMark()),
 						new Run(
@@ -352,7 +352,7 @@ namespace HtmlToOpenXml
 
                 h.Append(new Run(
                     new RunProperties {
-                        RunStyle = new RunStyle() { Val = htmlStyles.GetStyle("Hyperlink", StyleValues.Character) }
+                        RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.HyperlinkStyle, StyleValues.Character) }
                     },
                     new Text(description)));
                 p.Append(h);
@@ -424,11 +424,11 @@ namespace HtmlToOpenXml
 				new Endnote(
 					new Paragraph(
 						new ParagraphProperties {
-							ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle("EndnoteText", StyleValues.Paragraph) }
+							ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.EndnoteTextStyle, StyleValues.Paragraph) }
 						},
 						markerRun = new Run(
 							new RunProperties {
-								RunStyle = new RunStyle() { Val = htmlStyles.GetStyle("EndnoteReference", StyleValues.Character) }
+								RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.EndnoteReferenceStyle, StyleValues.Character) }
 							},
 							new FootnoteReferenceMark()),
 						new Run(

--- a/src/Html2OpenXml/HtmlDocumentStyle.cs
+++ b/src/Html2OpenXml/HtmlDocumentStyle.cs
@@ -26,6 +26,12 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public event EventHandler<StyleEventArgs> StyleMissing;
 
+		/// <summary>
+		/// Contains the default styles for new OpenXML elements
+		/// </summary>
+		public DefaultStyles DefaultStyles { get { return this.defaultStyles; } }
+
+		private DefaultStyles defaultStyles = new DefaultStyles();
 		private RunStyleCollection runStyle;
 		private TableStyleCollection tableStyle;
 		private ParagraphStyleCollection paraStyle;
@@ -196,45 +202,6 @@ namespace HtmlToOpenXml
 
 		//____________________________________________________________________
 		//
-
-		/// <summary>
-		/// Gets the default StyleId to apply on the any new paragraph.
-		/// </summary>
-		internal String DefaultParagraphStyle
-		{
-			get { return paraStyle.DefaultParagraphStyle; }
-			set { paraStyle.DefaultParagraphStyle = value; }
-		}
-
-		/// <summary>
-		/// Gets or sets the default paragraph style to apply on any new runs.
-		/// </summary>
-		public String DefaultStyle
-		{
-			get { return DefaultParagraphStyle ?? runStyle.DefaultRunStyle; }
-			set
-			{
-				if (String.IsNullOrEmpty(value))
-				{
-					runStyle.DefaultRunStyle = null;
-					this.DefaultParagraphStyle = null;
-					return;
-				}
-
-				Style s;
-				if (!knownStyles.TryGetValue(value, out s))
-				{
-					this.DefaultParagraphStyle = value;
-				}
-				else
-				{
-					if (s.Type.Equals<StyleValues>(StyleValues.Paragraph))
-						this.DefaultParagraphStyle = s.StyleId;
-					else
-						runStyle.DefaultRunStyle = s.StyleId;
-				}
-			}
-		}
 
         /// <summary>
         /// Gets or sets the beginning and ending characters used in the &lt;q&gt; tag.

--- a/src/Html2OpenXml/Primitives/DefaultStyles.cs
+++ b/src/Html2OpenXml/Primitives/DefaultStyles.cs
@@ -1,0 +1,139 @@
+/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
+ * 
+ * This source is subject to the Microsoft Permissive License.
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
+ * 
+ * THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+ * KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ */
+
+namespace HtmlToOpenXml
+{
+    /// <summary>
+    /// Contains the default styles of Word elements
+    /// </summary>
+    public class DefaultStyles
+    {
+        #region Caption
+        
+        /// <summary>
+        /// Default style for captions
+        /// </summary>
+        /// <value>Caption</value>
+        public string CaptionStyle { get; set; } = "Caption";
+
+        #endregion
+
+        #region Endnotes
+
+        /// <summary>
+        /// Default style for new endnote texts
+        /// </summary>
+        /// <value>EndnoteText</value>
+        public string EndnoteTextStyle { get; set; } = "EndnoteText";
+
+        /// <summary>
+        /// Default style for new endnote references
+        /// </summary>
+        /// <value>EndnoteReference</value>
+        public string EndnoteReferenceStyle { get; set; } = "EndnoteReference";
+
+        #endregion
+
+        #region Footnotes
+
+        /// <summary>
+        /// Default style for new footnote texts
+        /// </summary>
+        /// <value>FootnoteText</value>
+        public string FootnoteTextStyle { get; set; } = "FootnoteText";
+
+        /// <summary>
+        /// Default style for new footnote references
+        /// </summary>
+        /// <value>FootnoteReference</value>
+        public string FootnoteReferenceStyle { get; set; } = "FootnoteReference";
+
+        #endregion
+
+        #region Headings
+
+        /// <summary>
+        /// Default style for headings
+        /// Appends the level at the end of the style name
+        /// </summary>
+        /// <value>Heading</value>
+        public string HeadingStyle { get; set; } = "Heading";
+
+        #endregion
+
+        #region Hyperlink
+
+        /// <summary>
+        /// Default style for hyperlinks
+        /// </summary>
+        /// <value>Hyperlink</value>
+        public string HyperlinkStyle { get; set; } = "Hyperlink";
+
+        #endregion
+
+        #region Lists
+
+        /// <summary>
+        /// Default style for list paragraphs
+        /// </summary>
+        /// <value>ListParagraph</value>
+        public string ListParagraphStyle { get; set; } = "ListParagraph";
+
+        #endregion
+
+        #region Paragraph
+
+        /// <summary>
+        /// Default style for paragraphs
+        /// </summary>
+        /// <value>null</value>
+        public string ParagraphStyle { get; set; }
+
+        #endregion
+
+        #region Pre
+
+        /// <summary>
+        /// Default style for the &lt;pre&gt; table
+        /// </summary>
+        /// <value>TableGrid</value>
+        public string PreTableStyle { get; set; } = "TableGrid";
+
+        #endregion
+
+        #region Quotes
+
+        /// <summary>
+        /// Default style for quotes
+        /// </summary>
+        /// <value>Quote</value>
+        public string QuoteStyle { get; set; } = "Quote";
+
+        /// <summary>
+        /// Default style for intense quotes
+        /// </summary>
+        /// <value>IntenseQuote</value>
+        public string IntenseQuoteStyle { get; set; } = "IntenseQuote";
+
+        #endregion
+
+        #region Table
+
+        /// <summary>
+        /// Default style for tables
+        /// </summary>
+        /// <value>TableGrid</value>
+        public string TableStyle { get; set; } = "TableGrid";
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR allows end users to define default styles for diverse items:

- Caption
- EndnoteText
- EndnoteReference
- FootnoteText
- FootnoteReference
- Heading
- Hyperlink
- ListParagraph
- Paragraph (defaults to null in order to keep existing logic working)
- \<pre\> table (TableGrid)
- Quote
- IntenseQuote
- Table (TableGrid)

This can be useful if we're using WYSIWYG editors, where changing classes of items can not be simple. 

**Breaking changes:**
The fields `DefaultParagraphStyle` and `DefaultStyle` have been removed from `HtmlDocumentStyle.cs`.