### PR TITLE
keep processing html on image download error

### DIFF
--- a/src/Html2OpenXml/IO/ImagePrefetcher.cs
+++ b/src/Html2OpenXml/IO/ImagePrefetcher.cs
@@ -1,10 +1,10 @@
 ﻿/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
- * 
+ *
  * This source is subject to the Microsoft Permissive License.
  * Please see the License.txt file for more information.
  * All other rights reserved.
- * 
- * THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+ *
+ * THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
  * KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
  * PARTICULAR PURPOSE.
@@ -74,9 +74,18 @@ namespace HtmlToOpenXml.IO
         private HtmlImageInfo DownloadRemoteImage(string src)
         {
             Uri imageUri = new Uri(src, UriKind.RelativeOrAbsolute);
-            var response = resourceLoader.FetchAsync(imageUri, CancellationToken.None).Result;
-            if (response?.Content == null)
+            Resource response;
+            try
+            {
+                response = resourceLoader.FetchAsync(imageUri, CancellationToken.None).Result;
+                if (response?.Content == null)
+                    return null;
+            }
+            catch (Exception)
+            {
+                if (Logging.On) Logging.PrintVerbose(String.Format("Error fetching image from url: {0}", src));
                 return null;
+            }
 
             HtmlImageInfo info = new HtmlImageInfo() { Source = src };
             ImagePartType type;
@@ -163,7 +172,7 @@ namespace HtmlToOpenXml.IO
         private static bool TryInspectMimeType(string contentType, out ImagePartType type)
         {
             // can be null when the protocol used doesn't allow response headers
-            if (contentType != null && 
+            if (contentType != null &&
                 knownContentType.TryGetValue(contentType, out type))
                 return true;
 


### PR DESCRIPTION
Hi, first thanks a lot for this library!

We've been using it for a while, and today got a bug that, after investigation, turned out to be due to an [image](https://files.brightside.me/files/news/part_25/256760/7415810-ScreenShot2016-11-03at111127-1478160708-650-32e9147584-1478172290.jpg) that is not hosted anymore and that takes a while to resolve in a timeout error.

The way the lib is currently handling Image downloads, if any download fail then the error cascades all the way and an empty docx is generated.

In our case we found that it is desirable to fail gracefully and still generate the docx without the missing image, and just log the error for further analysis.

It would be great if we could get this merged, or if you have other suggestions please let me know!

Thanks!