### PR TITLE
support for styling ordered/unordered lists and list elements

### DIFF
--- a/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/NumberingListStyleCollection.cs
@@ -29,12 +29,14 @@ namespace HtmlToOpenXml
         private bool firstItem;
 		private Dictionary<String, Int32> knownAbsNumIds;
 		private Stack<KeyValuePair<Int32, int>> numInstances;
+        private Stack<string[]> listHtmlElementClasses;
 		private int headingNumberingId;
 
 		public NumberingListStyleCollection(MainDocumentPart mainPart)
 		{
 			this.mainPart = mainPart;
 			this.numInstances = new Stack<KeyValuePair<Int32, int>>();
+            listHtmlElementClasses = new Stack<string[]>();
 			InitNumberingIds();
 		}
 
@@ -251,6 +253,7 @@ namespace HtmlToOpenXml
 			bool orderedList = en.CurrentTag.Equals("<ol>", StringComparison.OrdinalIgnoreCase);
 
 			CreateList(type, orderedList);
+            listHtmlElementClasses.Push(en.Attributes.GetAsClass());
 		}
 
 		#endregion
@@ -264,6 +267,7 @@ namespace HtmlToOpenXml
 				numInstances.Pop();  // decrement for nested list
 
 			firstItem = true;
+            listHtmlElementClasses.Pop();
 		}
 
 		#endregion
@@ -491,6 +495,8 @@ namespace HtmlToOpenXml
 		{
 			get { return this.levelDepth; }
 		}
+
+        public string[] GetCurrentListClasses => listHtmlElementClasses.Peek();
 
 		/// <summary>
 		/// Gets the ID of the current list instance.

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -496,7 +496,7 @@ namespace HtmlToOpenXml
 			// Save the new paragraph reference to support nested numbering list.
 			Paragraph p = currentParagraph;
 			currentParagraph.InsertInProperties(prop => {
-				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.ListParagraphStyle, StyleValues.Paragraph) };
+				prop.ParagraphStyleId = new ParagraphStyleId() { Val = GetStyleIdForListItem(en) };
 				prop.Indentation = level < 2? null : new Indentation() { Left = (level * 780).ToString(CultureInfo.InvariantCulture) };
 				prop.NumberingProperties = new NumberingProperties {
 					NumberingLevelReference = new NumberingLevelReference() { Val = level - 1 },
@@ -514,7 +514,31 @@ namespace HtmlToOpenXml
 			this.elements.Clear();
 		}
 
-		#endregion
+        private string GetStyleIdForListItem(HtmlEnumerator en) 
+        { 
+            return GetStyleIdFromClasses(en.Attributes.GetAsClass()) 
+                   ?? GetStyleIdFromClasses(htmlStyles.NumberingList.GetCurrentListClasses) 
+                   ?? htmlStyles.DefaultStyles.ListParagraphStyle; 
+        }
+
+        private string GetStyleIdFromClasses(string[] classes)  
+        {  
+            if (classes != null) 
+            { 
+                foreach (string className in classes) 
+                { 
+                    string styleId = htmlStyles.GetStyle(className, StyleValues.Paragraph, ignoreCase: true); 
+                    if (styleId != null) 
+                    { 
+                        return styleId; 
+                    } 
+                } 
+            } 
+			 
+            return null; 
+        }
+
+        #endregion
 
 		#region ProcessLink
 


### PR DESCRIPTION
`<ul>`, `<ol>` and `<li>` elements can now be styled with Word Document styles using the class attribute. an unstyled `<li>` elements inherits its styling from its parent list element (`<ul>` or `<ol>`).

example:
```
<ul class="CustomList">
    <li>...</li>
    <li class="AlternateListItem">...</li>
    <li>...</li>
</ul>
```

If `CustomList` matches a (Word) Document Style, this style will be applied to the paragraphs that are created for every `<li>` child element of the `<ul>` list tag. If the `<li>` element has a class that matches a (Word) Document Style, this inherited behaviour will be overwritten. 

In the example above, the paragraph generated for the second `<li>` element will have the `AlternateListItem` style applied in Word, while the other two `<li>` elements will have the `CustomList` style applied, as inherited by their parent list tag.