### PR TITLE
Private field naming conventions added

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,17 +1,22 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "build",
                 "${workspaceRoot}/src/Html2OpenXml/HtmlToOpenXml.csproj",
                 "${workspaceRoot}/examples/Demo/Demo.csproj"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -1,0 +1,17 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}/src/Html2OpenXml/HtmlToOpenXml.csproj",
+                "${workspaceRoot}/examples/Demo/Demo.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Html2OpenXml/Collections/HtmlAttributeCollection.cs
+++ b/src/Html2OpenXml/Collections/HtmlAttributeCollection.cs
@@ -27,7 +27,7 @@ namespace HtmlToOpenXml
 		// This regex split the attributes. This line is valid and all the attributes are well discovered:
 		// <table border="1" contenteditable style="text-align: center; color: #ff00e6" cellpadding=0 cellspacing='0' align="center">
 		// RegexOptions.Singleline stands for dealing with attributes that contain newline (typically for base64 image, see issue #8)
-		private static Regex stripAttributesRegex = new Regex(@"
+		private static Regex _stripAttributesRegex = new Regex(@"
 #tag and its value surrounded by "" or '
 ((?<tag>\w+)=(?<sep>""|')\s*(?<val>\#?.*?)(\k<sep>|>))
 |
@@ -37,15 +37,15 @@ namespace HtmlToOpenXml
 # single tag (with no value): contenteditable
 \b(?<tag>\w+)\b", RegexOptions.IgnorePatternWhitespace| RegexOptions.Singleline);
 
-        private static Regex stripStyleAttributesRegex = new Regex(@"(?<name>.+?):\s*(?<val>[^;]+);*\s*");
+        private static Regex _stripStyleAttributesRegex = new Regex(@"(?<name>.+?):\s*(?<val>[^;]+);*\s*");
 
-		private Dictionary<string, string> attributes;
+		private Dictionary<string, string> _attributes;
 
 
 
 		private HtmlAttributeCollection()
 		{
-			this.attributes = new Dictionary<string, string>();
+			this._attributes = new Dictionary<string, string>();
 		}
 
 		public static HtmlAttributeCollection Parse(String htmlTag)
@@ -69,10 +69,10 @@ namespace HtmlToOpenXml
 				}
 			}
 
-			MatchCollection matches = stripAttributesRegex.Matches(htmlTag, startIndex);
+			MatchCollection matches = _stripAttributesRegex.Matches(htmlTag, startIndex);
 			foreach (Match m in matches)
 			{
-				collection.attributes[m.Groups["tag"].Value] = m.Groups["val"].Value;
+				collection._attributes[m.Groups["tag"].Value] = m.Groups["val"].Value;
 			}
 
 			return collection;
@@ -85,9 +85,9 @@ namespace HtmlToOpenXml
 
             // Encoded ':' and ';' characters are valid for browser but not handled by the regex (bug #13812 reported by robin391)
             // ex= <span style="text-decoration&#58;underline&#59;color:red">
-			MatchCollection matches = stripStyleAttributesRegex.Matches(HttpUtility.HtmlDecode(htmlTag));
+			MatchCollection matches = _stripStyleAttributesRegex.Matches(HttpUtility.HtmlDecode(htmlTag));
 			foreach (Match m in matches)
-				collection.attributes[m.Groups["name"].Value] = m.Groups["val"].Value;
+				collection._attributes[m.Groups["name"].Value] = m.Groups["val"].Value;
 
 			return collection;
 		}
@@ -97,7 +97,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public int Count
 		{
-			get { return attributes.Count; }
+			get { return _attributes.Count; }
 		}
 
 		/// <summary>
@@ -108,7 +108,7 @@ namespace HtmlToOpenXml
 			get
             {
                 string value;
-                return attributes.TryGetValue(name, out value)? value : null;
+                return _attributes.TryGetValue(name, out value)? value : null;
             }
 		}
 

--- a/src/Html2OpenXml/Collections/ParagraphStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/ParagraphStyleCollection.cs
@@ -22,11 +22,11 @@ namespace HtmlToOpenXml
 
 	sealed class ParagraphStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private readonly HtmlDocumentStyle documentStyle;
+		private readonly HtmlDocumentStyle _documentStyle;
 
         internal ParagraphStyleCollection(HtmlDocumentStyle documentStyle)
 		{
-			this.documentStyle = documentStyle;
+			this._documentStyle = documentStyle;
 		}
 
 		/// <summary>
@@ -96,7 +96,7 @@ namespace HtmlToOpenXml
 						styleAttributes.Add(new Languages() { Bidi = ci.Name });
 
 						// notify table
-						documentStyle.Tables.BeginTag(en.CurrentTag, new TableJustification() { Val = TableRowAlignmentValues.Right });
+						_documentStyle.Tables.BeginTag(en.CurrentTag, new TableJustification() { Val = TableRowAlignmentValues.Right });
 					}
 
 					containerStyleAttributes.Add(new ParagraphMarkRunProperties(lang));
@@ -175,7 +175,7 @@ namespace HtmlToOpenXml
 			{
 				for (int i = 0; i < classes.Length; i++)
 				{
-					string className = documentStyle.GetStyle(classes[i], StyleValues.Paragraph, ignoreCase: true);
+					string className = _documentStyle.GetStyle(classes[i], StyleValues.Paragraph, ignoreCase: true);
 					if (className != null)
 					{
 						containerStyleAttributes.Add(new ParagraphStyleId() { Val = className });
@@ -216,7 +216,7 @@ namespace HtmlToOpenXml
 			this.BeginTag(en.CurrentTag, containerStyleAttributes);
 
 			// Process general run styles
-			documentStyle.Runs.ProcessCommonAttributes(en, styleAttributes);
+			_documentStyle.Runs.ProcessCommonAttributes(en, styleAttributes);
 
 			return newParagraph;
 		}

--- a/src/Html2OpenXml/Collections/RunStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/RunStyleCollection.cs
@@ -22,11 +22,11 @@ namespace HtmlToOpenXml
 
 	sealed class RunStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private readonly HtmlDocumentStyle documentStyle;
+		private readonly HtmlDocumentStyle _documentStyle;
 
 		internal RunStyleCollection(HtmlDocumentStyle documentStyle)
 		{
-			this.documentStyle = documentStyle;
+			this._documentStyle = documentStyle;
 		}
 
 		/// <summary>
@@ -90,7 +90,7 @@ namespace HtmlToOpenXml
 			{
 				for (int i = 0; i < classes.Length; i++)
 				{
-					string className = documentStyle.GetStyle(classes[i], StyleValues.Character, ignoreCase: true);
+					string className = _documentStyle.GetStyle(classes[i], StyleValues.Character, ignoreCase: true);
 					if (className != null) // only one Style can be applied in OpenXml and dealing with inheritance is out of scope
 					{
 						styleAttributes.Add(new RunStyle() { Val = className });

--- a/src/Html2OpenXml/Collections/TableContext.cs
+++ b/src/Html2OpenXml/Collections/TableContext.cs
@@ -26,8 +26,8 @@ namespace HtmlToOpenXml
 			public CellPosition CellPosition;
             public HtmlTableSpanCollection RowSpan;
 		}
-		private Stack<Tuple> tables = new Stack<Tuple>(5);
-		private Tuple current;
+		private Stack<Tuple> _tables = new Stack<Tuple>(5);
+		private Tuple _current;
 
 
 
@@ -41,21 +41,21 @@ namespace HtmlToOpenXml
 
 		public void NewContext(Table table)
 		{
-			if (this.current != null)
-				tables.Push(current);
+			if (this._current != null)
+				_tables.Push(_current);
 
-            current = new Tuple() { Table = table, CellPosition = CellPosition.Empty, RowSpan = new HtmlTableSpanCollection() };
+            _current = new Tuple() { Table = table, CellPosition = CellPosition.Empty, RowSpan = new HtmlTableSpanCollection() };
 		}
 
 		public void CloseContext()
 		{
-			if (tables.Count > 0)
+			if (_tables.Count > 0)
 			{
-				current = tables.Pop();
+				_current = _tables.Pop();
 			}
 			else
 			{
-				this.current = null;
+				this._current = null;
 			}
 		}
 
@@ -64,7 +64,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool HasContext
 		{
-			get { return current != null; }
+			get { return _current != null; }
 		}
 
 		/// <summary>
@@ -73,8 +73,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public CellPosition CellPosition
 		{
-			get { return current.CellPosition; }
-			set { current.CellPosition = value; }
+			get { return _current.CellPosition; }
+			set { _current.CellPosition = value; }
 		}
 
 		/// <summary>
@@ -82,12 +82,12 @@ namespace HtmlToOpenXml
 		/// </summary>
         public HtmlTableSpanCollection RowSpan
 		{
-			get { return current.RowSpan; }
+			get { return _current.RowSpan; }
 		}
 
 		public Table CurrentTable
 		{
-			get { return current.Table; }
+			get { return _current.Table; }
 		}
 	}
 }

--- a/src/Html2OpenXml/Collections/TableStyleCollection.cs
+++ b/src/Html2OpenXml/Collections/TableStyleCollection.cs
@@ -21,18 +21,18 @@ namespace HtmlToOpenXml
 
 	sealed class TableStyleCollection : OpenXmlStyleCollectionBase
 	{
-		private readonly ParagraphStyleCollection paragraphStyle;
-		private readonly HtmlDocumentStyle documentStyle;
+		private readonly ParagraphStyleCollection _paragraphStyle;
+		private readonly HtmlDocumentStyle _documentStyle;
 
         internal TableStyleCollection(HtmlDocumentStyle documentStyle)
 		{
-			this.documentStyle = documentStyle;
-			paragraphStyle = new ParagraphStyleCollection(documentStyle);
+			this._documentStyle = documentStyle;
+			_paragraphStyle = new ParagraphStyleCollection(documentStyle);
 		}
 
 		internal override void Reset()
 		{
-			paragraphStyle.Reset();
+			_paragraphStyle.Reset();
 			base.Reset();
 		}
 
@@ -60,17 +60,17 @@ namespace HtmlToOpenXml
 
 			// Apply some style attributes on the unique Paragraph tag contained inside a table cell.
 			Paragraph p = tableCell.GetFirstChild<Paragraph>();
-			paragraphStyle.ApplyTags(p);
+			_paragraphStyle.ApplyTags(p);
 		}
 
 		public void BeginTagForParagraph(string name, params OpenXmlElement[] elements)
 		{
-			paragraphStyle.BeginTag(name, elements);
+			_paragraphStyle.BeginTag(name, elements);
 		}
 
 		public override void EndTag(string name)
 		{
-			paragraphStyle.EndTag(name);
+			_paragraphStyle.EndTag(name);
 			base.EndTag(name);
 		}
 
@@ -123,7 +123,7 @@ namespace HtmlToOpenXml
 			{
 				for (int i = 0; i < classes.Length; i++)
 				{
-					string className = documentStyle.GetStyle(classes[i], StyleValues.Table, ignoreCase: true);
+					string className = _documentStyle.GetStyle(classes[i], StyleValues.Table, ignoreCase: true);
 					if (className != null) // only one Style can be applied in OpenXml and dealing with inheritance is out of scope
 					{
 						containerStyleAttributes.Add(new RunStyle() { Val = className });
@@ -135,7 +135,7 @@ namespace HtmlToOpenXml
 			this.BeginTag(en.CurrentTag, containerStyleAttributes);
 
 			// Process general run styles
-			documentStyle.Runs.ProcessCommonAttributes(en, runStyleAttributes);
+			_documentStyle.Runs.ProcessCommonAttributes(en, runStyleAttributes);
 		}
 
 		#endregion

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -41,7 +41,7 @@ namespace HtmlToOpenXml
 
 			AlternateProcessHtmlChunks(en, en.ClosingCurrentTag);
 
-			if (elements.Count > 0 && elements[0] is Run)
+			if (_elements.Count > 0 && _elements[0] is Run)
 			{
 				string runStyle;
 				FootnoteEndnoteReferenceType reference;
@@ -49,19 +49,19 @@ namespace HtmlToOpenXml
 				if (this.AcronymPosition == AcronymPosition.PageEnd)
 				{
 					reference = new FootnoteReference() { Id = AddFootnoteReference(title) };
-					runStyle = htmlStyles.DefaultStyles.FootnoteReferenceStyle;
+					runStyle = _htmlStyles.DefaultStyles.FootnoteReferenceStyle;
 				}
 				else
 				{
 					reference = new EndnoteReference() { Id = AddEndnoteReference(title) };
-					runStyle = htmlStyles.DefaultStyles.EndnoteReferenceStyle;
+					runStyle = _htmlStyles.DefaultStyles.EndnoteReferenceStyle;
 				}
 
 				Run run;
-				elements.Add(
+				_elements.Add(
 					run = new Run(
 						new RunProperties {
-							RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(runStyle, StyleValues.Character) }
+							RunStyle = new RunStyle() { Val = _htmlStyles.GetStyle(runStyle, StyleValues.Character) }
 						},
 						reference));
 			}
@@ -78,7 +78,7 @@ namespace HtmlToOpenXml
 			string tagName = en.CurrentTag;
 			string cite = en.Attributes["cite"];
 
-			htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.IntenseQuoteStyle) });
+			_htmlStyles.Paragraph.BeginTag(en.CurrentTag, new ParagraphStyleId() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.IntenseQuoteStyle) });
 
 			AlternateProcessHtmlChunks(en, en.ClosingCurrentTag);
 
@@ -90,25 +90,25 @@ namespace HtmlToOpenXml
 				if (this.AcronymPosition == AcronymPosition.PageEnd)
 				{
 					reference = new FootnoteReference() { Id = AddFootnoteReference(cite) };
-					runStyle = htmlStyles.DefaultStyles.FootnoteReferenceStyle;
+					runStyle = _htmlStyles.DefaultStyles.FootnoteReferenceStyle;
 				}
 				else
 				{
 					reference = new EndnoteReference() { Id = AddEndnoteReference(cite) };
-					runStyle = htmlStyles.DefaultStyles.EndnoteReferenceStyle;
+					runStyle = _htmlStyles.DefaultStyles.EndnoteReferenceStyle;
 				}
 
 				Run run;
-				elements.Add(
+				_elements.Add(
 					run = new Run(
 						new RunProperties {
-							RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(runStyle, StyleValues.Character) }
+							RunStyle = new RunStyle() { Val = _htmlStyles.GetStyle(runStyle, StyleValues.Character) }
 						},
 						reference));
 			}
 
 			CompleteCurrentParagraph(true);
-			htmlStyles.Paragraph.EndTag(tagName);
+			_htmlStyles.Paragraph.EndTag(tagName);
 		}
 
 		#endregion
@@ -118,10 +118,10 @@ namespace HtmlToOpenXml
 		private void ProcessBody(HtmlEnumerator en)
 		{
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>();
-			htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
+			_htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
 
 			// Unsupported W3C attribute but claimed by users. Specified at <body> level, the page
 			// orientation is applied on the whole document
@@ -130,10 +130,10 @@ namespace HtmlToOpenXml
 			{
 				PageOrientationValues orientation = Converter.ToPageOrientation(attr);
 
-                SectionProperties sectionProperties = mainPart.Document.Body.GetFirstChild<SectionProperties>();
+                SectionProperties sectionProperties = _mainPart.Document.Body.GetFirstChild<SectionProperties>();
                 if (sectionProperties == null || sectionProperties.GetFirstChild<PageSize>() == null)
                 {
-                    mainPart.Document.Body.Append(HtmlConverter.ChangePageOrientation(orientation));
+                    _mainPart.Document.Body.Append(HtmlConverter.ChangePageOrientation(orientation));
                 }
                 else
                 {
@@ -154,7 +154,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessBr(HtmlEnumerator en)
 		{
-			elements.Add(new Run(new Break()));
+			_elements.Add(new Run(new Break()));
 		}
 
 		#endregion
@@ -163,7 +163,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessCite(HtmlEnumerator en)
 		{
-			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
+			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
 		}
 
 		#endregion
@@ -173,7 +173,7 @@ namespace HtmlToOpenXml
 		private void ProcessDefinitionList(HtmlEnumerator en)
 		{
 			ProcessParagraph(en);
-			currentParagraph.InsertInProperties(prop => prop.SpacingBetweenLines = new SpacingBetweenLines() { After = "0" });
+			_currentParagraph.InsertInProperties(prop => prop.SpacingBetweenLines = new SpacingBetweenLines() { After = "0" });
 		}
 
 		#endregion
@@ -184,16 +184,16 @@ namespace HtmlToOpenXml
 		{
 			AlternateProcessHtmlChunks(en, "</dd>");
 
-			currentParagraph = htmlStyles.Paragraph.NewParagraph();
-			currentParagraph.Append(elements);
-			currentParagraph.InsertInProperties(prop => {
+			_currentParagraph = _htmlStyles.Paragraph.NewParagraph();
+			_currentParagraph.Append(_elements);
+			_currentParagraph.InsertInProperties(prop => {
 				prop.Indentation = new Indentation() { FirstLine = "708" };
 				prop.SpacingBetweenLines = new SpacingBetweenLines() { After = "0" };
 			});
 
 			// Restore the original elements list
-			AddParagraph(currentParagraph);
-			this.elements.Clear();
+			AddParagraph(_currentParagraph);
+			this._elements.Clear();
 		}
 
 		#endregion
@@ -211,13 +211,13 @@ namespace HtmlToOpenXml
 				CompleteCurrentParagraph(newParagraph);
 
 				if (runStyleAttributes.Count > 0)
-					htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes);
+					_htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes);
 
 				// Any changes that requires a new paragraph?
 				if (newParagraph)
 				{
 					// Insert before the break, complete this paragraph and start a new one
-					this.paragraphs.Insert(this.paragraphs.Count - 1, currentParagraph);
+					this._paragraphs.Insert(this._paragraphs.Count - 1, _currentParagraph);
 					AlternateProcessHtmlChunks(en, en.ClosingCurrentTag);
 					CompleteCurrentParagraph();
 				}
@@ -255,7 +255,7 @@ namespace HtmlToOpenXml
 			}
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
+				_htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
 		}
 
 		#endregion
@@ -268,17 +268,17 @@ namespace HtmlToOpenXml
 
 			// support also style attributes for heading (in case of css override)
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>();
-			htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
+			_htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
 
 			AlternateProcessHtmlChunks(en, "</h" + level + ">");
 
-			Paragraph p = new Paragraph(elements);
+			Paragraph p = new Paragraph(_elements);
 			p.InsertInProperties(prop =>
-				prop.ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.HeadingStyle + level, StyleValues.Paragraph) });
+				prop.ParagraphStyleId = new ParagraphStyleId() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.HeadingStyle + level, StyleValues.Paragraph) });
 
 			// Check if the line starts with a number format (1., 1.1., 1.1.1.)
 			// If it does, make sure we make the heading a numbered item
-			OpenXmlElement firstElement = elements.First();
+			OpenXmlElement firstElement = _elements.First();
 			Match regexMatch = Regex.Match(firstElement.InnerText, @"(?m)^(\d+.)*\s");
 
 			// Make sure we only grab the heading if it starts with a number
@@ -289,15 +289,15 @@ namespace HtmlToOpenXml
 				// Strip numbers from text
 				firstElement.InnerXml = firstElement.InnerXml.Replace(firstElement.InnerText, firstElement.InnerText.Substring(indentLevel * 2 + 1)); // number, dot and whitespace
 
-				htmlStyles.NumberingList.ApplyNumberingToHeadingParagraph(p, indentLevel);
+				_htmlStyles.NumberingList.ApplyNumberingToHeadingParagraph(p, indentLevel);
 			}
 
-			htmlStyles.Paragraph.ApplyTags(p);
-			htmlStyles.Paragraph.EndTag("<h" + level + ">");
+			_htmlStyles.Paragraph.ApplyTags(p);
+			_htmlStyles.Paragraph.EndTag("<h" + level + ">");
 			
-			this.elements.Clear();
+			this._elements.Clear();
 			AddParagraph(p);
-			AddParagraph(currentParagraph = htmlStyles.Paragraph.NewParagraph());
+			AddParagraph(_currentParagraph = _htmlStyles.Paragraph.NewParagraph());
 		}
 
 		#endregion
@@ -312,9 +312,9 @@ namespace HtmlToOpenXml
 			// If the previous paragraph contains a bottom border or is a Table, we add some spacing between the <hr>
 			// and the previous element or Word will display only the last border.
 			// (see Remarks: http://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.bottomborder%28office.14%29.aspx)
-            if (paragraphs.Count >= 2)
+            if (_paragraphs.Count >= 2)
             {
-                OpenXmlCompositeElement previousElement = paragraphs[paragraphs.Count - 2];
+                OpenXmlCompositeElement previousElement = _paragraphs[_paragraphs.Count - 2];
                 bool addSpacing = false;
                 ParagraphProperties prop = previousElement.GetFirstChild<ParagraphProperties>();
                 if (prop != null)
@@ -331,13 +331,13 @@ namespace HtmlToOpenXml
 
                 if (addSpacing)
                 {
-                    currentParagraph.InsertInProperties(p => p.SpacingBetweenLines = new SpacingBetweenLines() { Before = "240" });
+                    _currentParagraph.InsertInProperties(p => p.SpacingBetweenLines = new SpacingBetweenLines() { Before = "240" });
                 }
             }
 
 			// if this paragraph has no children, it will be deleted in RemoveEmptyParagraphs()
 			// in order to kept the <hr>, we force an empty run
-            currentParagraph.Append(new Run());
+            _currentParagraph.Append(new Run());
 
 			// Get style from border (only top) or use Default style 
 			TopBorder hrBorderStyle = null;
@@ -348,7 +348,7 @@ namespace HtmlToOpenXml
 			else
 				hrBorderStyle = new TopBorder() { Val = BorderValues.Single, Size = 4U };
 
-			currentParagraph.InsertInProperties(prop => 
+			_currentParagraph.InsertInProperties(prop => 
 			prop.ParagraphBorders = new ParagraphBorders {
 				TopBorder = hrBorderStyle
 			});
@@ -361,10 +361,10 @@ namespace HtmlToOpenXml
 		private void ProcessHtml(HtmlEnumerator en)
 		{
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>();
-			htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
+			_htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
 		}
 
 		#endregion
@@ -383,7 +383,7 @@ namespace HtmlToOpenXml
 		{
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>() { style };
 			ProcessContainerAttributes(en, styleAttributes);
-			htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
+			_htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
 		}
 
 		#endregion
@@ -394,9 +394,9 @@ namespace HtmlToOpenXml
 		{
 			this.CompleteCurrentParagraph(true);
 
-			currentParagraph.Append(
+			_currentParagraph.Append(
 					new ParagraphProperties {
-						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) },
+						ParagraphStyleId = new ParagraphStyleId() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) },
 						KeepNext = new KeepNext()
 					},
 					new Run(
@@ -410,9 +410,9 @@ namespace HtmlToOpenXml
 
 			ProcessHtmlChunks(en, "</figcaption>");
 
-			if (elements.Count > 0) // any caption?
+			if (_elements.Count > 0) // any caption?
 			{
-				Text t = (elements[0] as Run).GetFirstChild<Text>();
+				Text t = (_elements[0] as Run).GetFirstChild<Text>();
 				t.Text = " " + t.InnerText; // append a space after the numero of the picture
 			}
 
@@ -477,7 +477,7 @@ namespace HtmlToOpenXml
 			{
 				Run run = new Run(drawing);
 				if (border.Val != BorderValues.None) run.InsertInProperties(prop => prop.Border = border);
-				elements.Add(run);
+				_elements.Add(run);
 			}
 		}
 
@@ -488,14 +488,14 @@ namespace HtmlToOpenXml
 		private void ProcessLi(HtmlEnumerator en)
 		{
 			CompleteCurrentParagraph(false);
-			currentParagraph = htmlStyles.Paragraph.NewParagraph();
+			_currentParagraph = _htmlStyles.Paragraph.NewParagraph();
 
-			int numberingId = htmlStyles.NumberingList.ProcessItem(en);
-			int level = htmlStyles.NumberingList.LevelIndex;
+			int numberingId = _htmlStyles.NumberingList.ProcessItem(en);
+			int level = _htmlStyles.NumberingList.LevelIndex;
 
 			// Save the new paragraph reference to support nested numbering list.
-			Paragraph p = currentParagraph;
-			currentParagraph.InsertInProperties(prop => {
+			Paragraph p = _currentParagraph;
+			_currentParagraph.InsertInProperties(prop => {
 				prop.ParagraphStyleId = new ParagraphStyleId() { Val = GetStyleIdForListItem(en) };
 				prop.Indentation = level < 2? null : new Indentation() { Left = (level * 780).ToString(CultureInfo.InvariantCulture) };
 				prop.NumberingProperties = new NumberingProperties {
@@ -505,20 +505,20 @@ namespace HtmlToOpenXml
 			});
 
 			// Restore the original elements list
-			AddParagraph(currentParagraph);
+			AddParagraph(_currentParagraph);
 
 			// Continue to process the html until we found </li>
-			HtmlStyles.Paragraph.ApplyTags(currentParagraph);
+			HtmlStyles.Paragraph.ApplyTags(_currentParagraph);
 			AlternateProcessHtmlChunks(en, "</li>");
-			p.Append(elements);
-			this.elements.Clear();
+			p.Append(_elements);
+			this._elements.Clear();
 		}
 
         private string GetStyleIdForListItem(HtmlEnumerator en) 
         { 
             return GetStyleIdFromClasses(en.Attributes.GetAsClass()) 
-                   ?? GetStyleIdFromClasses(htmlStyles.NumberingList.GetCurrentListClasses) 
-                   ?? htmlStyles.DefaultStyles.ListParagraphStyle; 
+                   ?? GetStyleIdFromClasses(_htmlStyles.NumberingList.GetCurrentListClasses) 
+                   ?? _htmlStyles.DefaultStyles.ListParagraphStyle; 
         }
 
         private string GetStyleIdFromClasses(string[] classes)  
@@ -527,7 +527,7 @@ namespace HtmlToOpenXml
             { 
                 foreach (string className in classes) 
                 { 
-                    string styleId = htmlStyles.GetStyle(className, StyleValues.Paragraph, ignoreCase: true); 
+                    string styleId = _htmlStyles.GetStyle(className, StyleValues.Paragraph, ignoreCase: true); 
                     if (styleId != null) 
                     { 
                         return styleId; 
@@ -568,7 +568,7 @@ namespace HtmlToOpenXml
 				// ensure the links does not start with javascript:
 				else if (Uri.TryCreate(att, UriKind.Absolute, out uri) && uri.Scheme != "javascript")
 				{
-					HyperlinkRelationship extLink = mainPart.AddHyperlinkRelationship(uri, true);
+					HyperlinkRelationship extLink = _mainPart.AddHyperlinkRelationship(uri, true);
 
 					h = new Hyperlink(
 						) { History = true, Id = extLink.Id };
@@ -587,12 +587,12 @@ namespace HtmlToOpenXml
 
 			AlternateProcessHtmlChunks(en, "</a>");
 
-			if (elements.Count == 0) return;
+			if (_elements.Count == 0) return;
 
 			// Let's see whether the link tag include an image inside its body.
 			// If so, the Hyperlink OpenXmlElement is lost and we'll keep only the images
 			// and applied a HyperlinkOnClick attribute.
-			List<OpenXmlElement> imageInLink = elements.FindAll(e => { return e.HasChild<Drawing>(); });
+			List<OpenXmlElement> imageInLink = _elements.FindAll(e => { return e.HasChild<Drawing>(); });
 			if (imageInLink.Count != 0)
 			{
 				for (int i = 0; i < imageInLink.Count; i++)
@@ -610,7 +610,7 @@ namespace HtmlToOpenXml
 			}
 
 			// Append the processed elements and put them to the Run of the Hyperlink
-			h.Append(elements);
+			h.Append(_elements);
 
 			// can't use GetFirstChild<Run> or we may find the one containing the image
 			foreach (var el in h.ChildElements)
@@ -619,15 +619,15 @@ namespace HtmlToOpenXml
 				if (run != null && !run.HasChild<Drawing>())
 				{
 					run.InsertInProperties(prop =>
-						prop.RunStyle = new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.HyperlinkStyle, StyleValues.Character) });
+						prop.RunStyle = new RunStyle() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.HyperlinkStyle, StyleValues.Character) });
 					break;
 				}
 			}
 
-			this.elements.Clear();
+			this._elements.Clear();
 
 			// Append the hyperlink
-			elements.Add(h);
+			_elements.Add(h);
 
 			if (imageInLink.Count > 0) CompleteCurrentParagraph(true);
 		}
@@ -638,7 +638,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessNumberingList(HtmlEnumerator en)
 		{
-			htmlStyles.NumberingList.BeginList(en);
+			_htmlStyles.NumberingList.BeginList(en);
 		}
 
 		#endregion
@@ -658,7 +658,7 @@ namespace HtmlToOpenXml
 				JustificationValues? align = Converter.ToParagraphAlign(attrValue);
 				if (align.HasValue)
 				{
-					currentParagraph.InsertInProperties(prop => prop.Justification = new Justification { Val = align });
+					_currentParagraph.InsertInProperties(prop => prop.Justification = new Justification { Val = align });
 				}
 			}
 
@@ -666,7 +666,7 @@ namespace HtmlToOpenXml
 			bool newParagraph = ProcessContainerAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
 
 			if (newParagraph)
 			{
@@ -682,14 +682,14 @@ namespace HtmlToOpenXml
 		private void ProcessPre(HtmlEnumerator en)
 		{
 			CompleteCurrentParagraph();
-			currentParagraph = htmlStyles.Paragraph.NewParagraph();
+			_currentParagraph = _htmlStyles.Paragraph.NewParagraph();
 
 			// Oftenly, <pre> tag are used to renders some code examples. They look better inside a table
             if (this.RenderPreAsTable)
             {
                 Table currentTable = new Table(
                     new TableProperties (
-                        new TableStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.PreTableStyle, StyleValues.Table) },
+                        new TableStyle() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.PreTableStyle, StyleValues.Table) },
                         new TableWidth() { Type = TableWidthUnitValues.Pct, Width = "5000" } // 100% * 50
 					),
                     new TableGrid(
@@ -705,15 +705,15 @@ namespace HtmlToOpenXml
                                    new BottomBorder() { Val = BorderValues.Single },
                                    new RightBorder() { Val = BorderValues.Single })
                             },
-                            currentParagraph))
+                            _currentParagraph))
                 );
 
                 AddParagraph(currentTable);
-                tables.NewContext(currentTable);
+                _tables.NewContext(currentTable);
             }
             else
             {
-                AddParagraph(currentParagraph);
+                AddParagraph(_currentParagraph);
             }
 
 			// Process the entire <pre> tag and append it to the document
@@ -721,15 +721,15 @@ namespace HtmlToOpenXml
 			ProcessContainerAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());
 
 			AlternateProcessHtmlChunks(en, "</pre>");
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.EndTag(en.CurrentTag);
+				_htmlStyles.Runs.EndTag(en.CurrentTag);
 
 			if (RenderPreAsTable)
-				tables.CloseContext();
+				_tables.CloseContext();
 
 			CompleteCurrentParagraph();
 		}
@@ -747,10 +747,10 @@ namespace HtmlToOpenXml
 				new Text(" " + HtmlStyles.QuoteCharacters.Prefix) { Space = SpaceProcessingModeValues.Preserve }
 			);
 
-			htmlStyles.Runs.ApplyTags(run);
-			elements.Add(run);
+			_htmlStyles.Runs.ApplyTags(run);
+			_elements.Add(run);
 
-			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
+			ProcessHtmlElement<RunStyle>(en, new RunStyle() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.QuoteStyle, StyleValues.Character) });
 		}
 
 		#endregion
@@ -767,7 +767,7 @@ namespace HtmlToOpenXml
 			bool newParagraph = ProcessContainerAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
+				_htmlStyles.Runs.MergeTag(en.CurrentTag, styleAttributes);
 
 			if (newParagraph)
 			{
@@ -810,14 +810,14 @@ namespace HtmlToOpenXml
 		private void ProcessTable(HtmlEnumerator en)
 		{
 			TableProperties properties = new TableProperties(
-				new TableStyle() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.TableStyle, StyleValues.Table) }
+				new TableStyle() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.TableStyle, StyleValues.Table) }
 			);
 			Table currentTable = new Table(properties);
 
 			string classValue = en.Attributes["class"];
 			if (classValue != null)
 			{
-				classValue = htmlStyles.GetStyle(classValue, StyleValues.Table, ignoreCase: true);
+				classValue = _htmlStyles.GetStyle(classValue, StyleValues.Table, ignoreCase: true);
 				if (classValue != null)
 					properties.TableStyle.Val = classValue;
 			}
@@ -829,17 +829,17 @@ namespace HtmlToOpenXml
 				if (classValue != null)
 				{
 					// check whether the style in use have borders
-                    String styleId = this.htmlStyles.GetStyle(classValue, StyleValues.Table, true);
+                    String styleId = this._htmlStyles.GetStyle(classValue, StyleValues.Table, true);
 					if (styleId != null)
                     {
-                        var s = mainPart.StyleDefinitionsPart.Styles.Elements<Style>().First(e => e.StyleId == styleId);
+                        var s = _mainPart.StyleDefinitionsPart.Styles.Elements<Style>().First(e => e.StyleId == styleId);
                         if (s.StyleTableProperties.TableBorders != null) handleBorders = false;
                     }
 				}
 
 				// If the border has been specified, we display the Table Grid style which display
 				// its grid lines. Otherwise the default table style hides the grid lines.
-				if (handleBorders && properties.TableStyle.Val != htmlStyles.DefaultStyles.TableStyle)
+				if (handleBorders && properties.TableStyle.Val != _htmlStyles.DefaultStyles.TableStyle)
 				{
 					uint borderSize = border.Value > 1? (uint) new Unit(UnitMetric.Pixel, border.Value).ValueInDxa : 1;
 					properties.TableBorders = new TableBorders() {
@@ -968,32 +968,32 @@ namespace HtmlToOpenXml
             }
 
 			List<OpenXmlElement> runStyleAttributes = new List<OpenXmlElement>();
-			htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
+			_htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
 			if (runStyleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
 
 
 			// are we currently inside another table?
-			if (tables.HasContext)
+			if (_tables.HasContext)
 			{
 				// Okay we will insert nested table but beware the paragraph inside TableCell should contains at least 1 run.
 
-				TableCell currentCell = tables.CurrentTable.GetLastChild<TableRow>().GetLastChild<TableCell>();
+				TableCell currentCell = _tables.CurrentTable.GetLastChild<TableRow>().GetLastChild<TableCell>();
 				// don't add an empty paragraph if not required (bug #13608 by zanjo)
-				if (elements.Count == 0) currentCell.Append(currentTable);
+				if (_elements.Count == 0) currentCell.Append(currentTable);
 				else
 				{
-					currentCell.Append(new Paragraph(elements), currentTable);
-					elements.Clear();
+					currentCell.Append(new Paragraph(_elements), currentTable);
+					_elements.Clear();
 				}
 			}
 			else
 			{
 				CompleteCurrentParagraph();
-				this.paragraphs.Add(currentTable);
+				this._paragraphs.Add(currentTable);
 			}
 
-			tables.NewContext(currentTable);
+			_tables.NewContext(currentTable);
 		}
 
 		#endregion
@@ -1002,7 +1002,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessTableCaption(HtmlEnumerator en)
 		{
-			if (!tables.HasContext) return;
+			if (!_tables.HasContext) return;
 
 			string att = en.StyleAttributes["text-align"];
 			if (att == null) att = en.Attributes["align"];
@@ -1011,7 +1011,7 @@ namespace HtmlToOpenXml
 
 			var legend = new Paragraph(
 					new ParagraphProperties {
-						ParagraphStyleId = new ParagraphStyleId() { Val = htmlStyles.GetStyle(htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) }
+						ParagraphStyleId = new ParagraphStyleId() { Val = _htmlStyles.GetStyle(_htmlStyles.DefaultStyles.CaptionStyle, StyleValues.Paragraph) }
 					},
 					new Run(
 						new FieldChar() { FieldCharType = FieldCharValues.Begin }),
@@ -1020,8 +1020,8 @@ namespace HtmlToOpenXml
 					new Run(
 						new FieldChar() { FieldCharType = FieldCharValues.End })
 				);
-			legend.Append(elements);
-			elements.Clear();
+			legend.Append(_elements);
+			_elements.Clear();
 
 			if (att != null)
 			{
@@ -1033,7 +1033,7 @@ namespace HtmlToOpenXml
 			{
 				// If no particular alignement has been specified for the legend, we will align the legend
 				// relative to the owning table
-				TableProperties props = tables.CurrentTable.GetFirstChild<TableProperties>();
+				TableProperties props = _tables.CurrentTable.GetFirstChild<TableProperties>();
 				if (props != null)
 				{
 					TableJustification justif = props.GetFirstChild<TableJustification>();
@@ -1043,9 +1043,9 @@ namespace HtmlToOpenXml
 			}
 
 			if (this.TableCaptionPosition == CaptionPositionValues.Above)
-				this.paragraphs.Insert(this.paragraphs.Count - 1, legend);
+				this._paragraphs.Insert(this._paragraphs.Count - 1, legend);
 			else
-				this.paragraphs.Add(legend);
+				this._paragraphs.Add(legend);
 		}
 
 		#endregion
@@ -1056,12 +1056,12 @@ namespace HtmlToOpenXml
 		{
 			// in case the html is bad-formed and use <tr> outside a <table> tag, we will ensure
 			// a table context exists.
-			if (!tables.HasContext) return;
+			if (!_tables.HasContext) return;
 
 			TableRowProperties properties = new TableRowProperties();
 			List<OpenXmlElement> runStyleAttributes = new List<OpenXmlElement>();
 
-			htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
+			_htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
 
 			Unit unit = en.StyleAttributes.GetAsUnit("height");
 			if (!unit.IsValid) unit = en.Attributes.GetAsUnit("height");
@@ -1082,12 +1082,12 @@ namespace HtmlToOpenXml
 			TableRow row = new TableRow();
 			row.TableRowProperties = properties;
 
-			htmlStyles.Runs.ProcessCommonAttributes(en, runStyleAttributes);
+			_htmlStyles.Runs.ProcessCommonAttributes(en, runStyleAttributes);
 			if (runStyleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
 
-			tables.CurrentTable.Append(row);
-			tables.CellPosition = new CellPosition(tables.CellPosition.Row + 1, 0);
+			_tables.CurrentTable.Append(row);
+			_tables.CellPosition = new CellPosition(_tables.CellPosition.Row + 1, 0);
 		}
 
 		#endregion
@@ -1096,7 +1096,7 @@ namespace HtmlToOpenXml
 
 		private void ProcessTableColumn(HtmlEnumerator en)
 		{
-			if (!tables.HasContext) return;
+			if (!_tables.HasContext) return;
 
 			TableCellProperties properties = new TableCellProperties();
             // in Html, table cell are vertically centered by default
@@ -1138,14 +1138,14 @@ namespace HtmlToOpenXml
 			{
 				properties.VerticalMerge = new VerticalMerge() { Val = MergedCellValues.Restart };
 
-				var p = tables.CellPosition;
+				var p = _tables.CellPosition;
                 int shift = 0;
                 // if there is already a running rowSpan on a left-sided column, we have to shift this position
-                foreach (var rs in tables.RowSpan)
+                foreach (var rs in _tables.RowSpan)
                     if (rs.CellOrigin.Row < p.Row && rs.CellOrigin.Column <= p.Column + shift) shift++;
 
                 p.Offset(0, shift);
-                tables.RowSpan.Add(new HtmlTableSpan(p) {
+                _tables.RowSpan.Add(new HtmlTableSpan(p) {
                     RowSpan = rowspan.Value - 1,
                     ColSpan = colspan.HasValue && rowspan.Value > 1 ? colspan.Value : 0
                 });
@@ -1160,12 +1160,12 @@ namespace HtmlToOpenXml
 					case "tb-lr":
 						properties.TextDirection = new TextDirection() { Val = TextDirectionValues.BottomToTopLeftToRight };
 						properties.TableCellVerticalAlignment = new TableCellVerticalAlignment() { Val = TableVerticalAlignmentValues.Center };
-						htmlStyles.Tables.BeginTagForParagraph(en.CurrentTag, new Justification() { Val = JustificationValues.Center });
+						_htmlStyles.Tables.BeginTagForParagraph(en.CurrentTag, new Justification() { Val = JustificationValues.Center });
 						break;
 					case "tb-rl":
 						properties.TextDirection = new TextDirection() { Val = TextDirectionValues.TopToBottomRightToLeft };
 						properties.TableCellVerticalAlignment = new TableCellVerticalAlignment() { Val = TableVerticalAlignmentValues.Center };
-						htmlStyles.Tables.BeginTagForParagraph(en.CurrentTag, new Justification() { Val = JustificationValues.Center });
+						_htmlStyles.Tables.BeginTagForParagraph(en.CurrentTag, new Justification() { Val = JustificationValues.Center });
 						break;
 				}
 			}
@@ -1215,17 +1215,17 @@ namespace HtmlToOpenXml
 					properties.TableCellBorders.BottomBorder = new BottomBorder { Val = border.Bottom.Style, Color = StringValue.FromString(border.Bottom.Color.ToHexString()), Size = (uint)border.Bottom.Width.ValueInDxa };
 			}
 
-			htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
+			_htmlStyles.Tables.ProcessCommonAttributes(en, runStyleAttributes);
 			if (styleAttributes.Count > 0)
-				htmlStyles.Tables.BeginTag(en.CurrentTag, styleAttributes);
+				_htmlStyles.Tables.BeginTag(en.CurrentTag, styleAttributes);
 			if (runStyleAttributes.Count > 0)
-				htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
+				_htmlStyles.Runs.BeginTag(en.CurrentTag, runStyleAttributes.ToArray());
 
 			TableCell cell = new TableCell();
 			if (properties.HasChildren) cell.TableCellProperties = properties;
                   
             // The heightUnit value used to append a height to the TableRowHeight.
-            var row = tables.CurrentTable.GetLastChild<TableRow>();
+            var row = _tables.CurrentTable.GetLastChild<TableRow>();
 
             switch (heightUnit.Type)
             {
@@ -1245,7 +1245,7 @@ namespace HtmlToOpenXml
 			else
 			{
 				// we create a new currentParagraph to add new runs inside the TableCell
-				cell.Append(currentParagraph = new Paragraph());
+				cell.Append(_currentParagraph = new Paragraph());
 			}
 		}
 
@@ -1257,10 +1257,10 @@ namespace HtmlToOpenXml
 		{
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>();
 
-			htmlStyles.Tables.ProcessCommonAttributes(en, styleAttributes);
+			_htmlStyles.Tables.ProcessCommonAttributes(en, styleAttributes);
 
 			if (styleAttributes.Count > 0)
-				htmlStyles.Tables.BeginTag(en.CurrentTag, styleAttributes.ToArray());
+				_htmlStyles.Tables.BeginTag(en.CurrentTag, styleAttributes.ToArray());
 		}
 
 		#endregion
@@ -1299,7 +1299,7 @@ namespace HtmlToOpenXml
 		private void ProcessClosingBlockQuote(HtmlEnumerator en)
 		{
 			CompleteCurrentParagraph(true);
-			htmlStyles.Paragraph.EndTag("<blockquote>");
+			_htmlStyles.Paragraph.EndTag("<blockquote>");
 		}
 
 		#endregion
@@ -1320,8 +1320,8 @@ namespace HtmlToOpenXml
 		private void ProcessClosingTag(HtmlEnumerator en)
 		{
 			string openingTag = en.CurrentTag.Replace("/", "");
-			htmlStyles.Runs.EndTag(openingTag);
-			htmlStyles.Paragraph.EndTag(openingTag);
+			_htmlStyles.Runs.EndTag(openingTag);
+			_htmlStyles.Paragraph.EndTag(openingTag);
 		}
 
 		#endregion
@@ -1330,12 +1330,12 @@ namespace HtmlToOpenXml
 
 		private void ProcessClosingNumberingList(HtmlEnumerator en)
 		{
-			htmlStyles.NumberingList.EndList();
+			_htmlStyles.NumberingList.EndList();
 
 			// If we are no more inside a list, we move to another paragraph (as we created
 			// one for containing all the <li>. This will ensure the next run will not be added to the <li>.
-			if (htmlStyles.NumberingList.LevelIndex == 0)
-				AddParagraph(currentParagraph = htmlStyles.Paragraph.NewParagraph());
+			if (_htmlStyles.NumberingList.LevelIndex == 0)
+				AddParagraph(_currentParagraph = _htmlStyles.Paragraph.NewParagraph());
 		}
 
 		#endregion
@@ -1347,8 +1347,8 @@ namespace HtmlToOpenXml
 			CompleteCurrentParagraph(true);
 
 			string tag = en.CurrentTag.Replace("/", "");
-			htmlStyles.Runs.EndTag(tag);
-			htmlStyles.Paragraph.EndTag(tag);
+			_htmlStyles.Runs.EndTag(tag);
+			_htmlStyles.Paragraph.EndTag(tag);
 		}
 
 		#endregion
@@ -1360,10 +1360,10 @@ namespace HtmlToOpenXml
 			Run run = new Run(
 				new Text(HtmlStyles.QuoteCharacters.Suffix) { Space = SpaceProcessingModeValues.Preserve }
 			);
-			htmlStyles.Runs.ApplyTags(run);
-			elements.Add(run);
+			_htmlStyles.Runs.ApplyTags(run);
+			_elements.Add(run);
 
-			htmlStyles.Runs.EndTag("<q>");
+			_htmlStyles.Runs.EndTag("<q>");
 		}
 
 		#endregion
@@ -1372,10 +1372,10 @@ namespace HtmlToOpenXml
 
 		private void ProcessClosingTable(HtmlEnumerator en)
 		{
-			htmlStyles.Tables.EndTag("<table>");
-			htmlStyles.Runs.EndTag("<table>");
+			_htmlStyles.Tables.EndTag("<table>");
+			_htmlStyles.Runs.EndTag("<table>");
 
-			TableRow row = tables.CurrentTable.GetFirstChild<TableRow>();
+			TableRow row = _tables.CurrentTable.GetFirstChild<TableRow>();
 			// Is this a misformed or empty table?
 			if (row != null)
 			{
@@ -1390,13 +1390,13 @@ namespace HtmlToOpenXml
 					}
 				}
 
-				tables.CurrentTable.InsertAt<TableGrid>(grid, 1);
+				_tables.CurrentTable.InsertAt<TableGrid>(grid, 1);
 			}
 
-			tables.CloseContext();
+			_tables.CloseContext();
 
-			if (!tables.HasContext)
-				AddParagraph(currentParagraph = htmlStyles.Paragraph.NewParagraph());
+			if (!_tables.HasContext)
+				AddParagraph(_currentParagraph = _htmlStyles.Paragraph.NewParagraph());
 		}
 
 		#endregion
@@ -1407,7 +1407,7 @@ namespace HtmlToOpenXml
 		{
 			string closingTag = en.CurrentTag.Replace("/", "");
 
-			htmlStyles.Tables.EndTag(closingTag);
+			_htmlStyles.Tables.EndTag(closingTag);
 		}
 
 		#endregion
@@ -1416,8 +1416,8 @@ namespace HtmlToOpenXml
 
 		private void ProcessClosingTableRow(HtmlEnumerator en)
 		{
-			if (!tables.HasContext) return;
-			TableRow row = tables.CurrentTable.GetLastChild<TableRow>();
+			if (!_tables.HasContext) return;
+			TableRow row = _tables.CurrentTable.GetLastChild<TableRow>();
 			if (row == null) return;
 
 			// Word will not open documents with empty rows (reported by scwebgroup)
@@ -1428,13 +1428,13 @@ namespace HtmlToOpenXml
 			}
 
 			// Add empty columns to fill rowspan
-			if (tables.RowSpan.Count > 0)
+			if (_tables.RowSpan.Count > 0)
 			{
-				int rowIndex = tables.CellPosition.Row;
+				int rowIndex = _tables.CellPosition.Row;
 
-				for (int i = 0; i < tables.RowSpan.Count; i++)
+				for (int i = 0; i < _tables.RowSpan.Count; i++)
 				{
-					HtmlTableSpan tspan = tables.RowSpan[i];
+					HtmlTableSpan tspan = _tables.RowSpan[i];
 					if (tspan.CellOrigin.Row == rowIndex) continue;
 
                     TableCell emptyCell = new TableCell(new TableCellProperties {
@@ -1443,7 +1443,7 @@ namespace HtmlToOpenXml
 							            new Paragraph());
 
                     tspan.RowSpan--;
-                    if (tspan.RowSpan == 0) { tables.RowSpan.RemoveAt(i); i--; }
+                    if (tspan.RowSpan == 0) { _tables.RowSpan.RemoveAt(i); i--; }
 
                     // in case of both colSpan + rowSpan on the same cell, we have to reverberate the rowSpan on the next columns too
                     if (tspan.ColSpan > 0) emptyCell.TableCellProperties.GridSpan = new GridSpan() { Val = tspan.ColSpan };
@@ -1468,8 +1468,8 @@ namespace HtmlToOpenXml
                 }
 			}
 
-			htmlStyles.Tables.EndTag("<tr>");
-			htmlStyles.Runs.EndTag("<tr>");
+			_htmlStyles.Tables.EndTag("<tr>");
+			_htmlStyles.Runs.EndTag("<tr>");
 		}
 
 		#endregion
@@ -1478,16 +1478,16 @@ namespace HtmlToOpenXml
 
 		private void ProcessClosingTableColumn(HtmlEnumerator en)
 		{
-			if (!tables.HasContext)
+			if (!_tables.HasContext)
 			{
 				// When the Html is bad-formed and doesn't contain <table>, the browser renders the column separated by a space.
 				// So we do the same here
 				Run run = new Run(new Text(" ") { Space = SpaceProcessingModeValues.Preserve });
-				htmlStyles.Runs.ApplyTags(run);
-				elements.Add(run);
+				_htmlStyles.Runs.ApplyTags(run);
+				_elements.Add(run);
 				return;
 			}
-			TableCell cell = tables.CurrentTable.GetLastChild<TableRow>().GetLastChild<TableCell>();
+			TableCell cell = _tables.CurrentTable.GetLastChild<TableRow>().GetLastChild<TableCell>();
 
 			// As we add automatically a paragraph to the cell once we create it, we'll remove it if finally, it was not used.
 			// For all the other children, we will ensure there is no more empty paragraphs (similarly to what we do at the end
@@ -1504,19 +1504,19 @@ namespace HtmlToOpenXml
 			// We add this paragraph regardless it has elements or not. A TableCell requires at least a Paragraph, as the last child of
 			// of a table cell.
 			// additional check for a proper cleaning (reported by antgraf github.com/onizet/html2openxml/discussions/272744)
-			if (!(cell.LastChild is Paragraph) || elements.Count > 0) cell.Append(new Paragraph(elements));
+			if (!(cell.LastChild is Paragraph) || _elements.Count > 0) cell.Append(new Paragraph(_elements));
 
-			htmlStyles.Tables.ApplyTags(cell);
+			_htmlStyles.Tables.ApplyTags(cell);
 
 			// Reset all our variables and move to next cell
-			this.elements.Clear();
+			this._elements.Clear();
 			String openingTag = en.CurrentTag.Replace("/", "");
-			htmlStyles.Tables.EndTag(openingTag);
-			htmlStyles.Runs.EndTag(openingTag);
+			_htmlStyles.Tables.EndTag(openingTag);
+			_htmlStyles.Runs.EndTag(openingTag);
 
-			var pos = tables.CellPosition;
+			var pos = _tables.CellPosition;
 			pos.Column++;
-			tables.CellPosition = pos;
+			_tables.CellPosition = pos;
 		}
 
 		#endregion

--- a/src/Html2OpenXml/HtmlDocumentStyle.cs
+++ b/src/Html2OpenXml/HtmlDocumentStyle.cs
@@ -29,25 +29,25 @@ namespace HtmlToOpenXml
 		/// <summary>
 		/// Contains the default styles for new OpenXML elements
 		/// </summary>
-		public DefaultStyles DefaultStyles { get { return this.defaultStyles; } }
+		public DefaultStyles DefaultStyles { get { return this._defaultStyles; } }
 
-		private DefaultStyles defaultStyles = new DefaultStyles();
-		private RunStyleCollection runStyle;
-		private TableStyleCollection tableStyle;
-		private ParagraphStyleCollection paraStyle;
-        private NumberingListStyleCollection listStyle;
-		private OpenXmlDocumentStyleCollection knownStyles;
-		private MainDocumentPart mainPart;
+		private DefaultStyles _defaultStyles = new DefaultStyles();
+		private RunStyleCollection _runStyle;
+		private TableStyleCollection _tableStyle;
+		private ParagraphStyleCollection _paraStyle;
+        private NumberingListStyleCollection _listStyle;
+		private OpenXmlDocumentStyleCollection _knownStyles;
+		private MainDocumentPart _mainPart;
 
 
 		internal HtmlDocumentStyle(MainDocumentPart mainPart)
 		{
 			PrepareStyles(mainPart);
-			tableStyle = new TableStyleCollection(this);
-			runStyle = new RunStyleCollection(this);
-			paraStyle = new ParagraphStyleCollection(this);
+			_tableStyle = new TableStyleCollection(this);
+			_runStyle = new RunStyleCollection(this);
+			_paraStyle = new ParagraphStyleCollection(this);
             this.QuoteCharacters = QuoteChars.IE;
-			this.mainPart = mainPart;
+			this._mainPart = mainPart;
 		}
 
 		//____________________________________________________________________
@@ -60,7 +60,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		internal void PrepareStyles(MainDocumentPart mainPart)
 		{
-			knownStyles = new OpenXmlDocumentStyleCollection();
+			_knownStyles = new OpenXmlDocumentStyleCollection();
 			if (mainPart.StyleDefinitionsPart == null) return;
 
 			Styles styles = mainPart.StyleDefinitionsPart.Styles;
@@ -71,10 +71,10 @@ namespace HtmlToOpenXml
 				if (n != null)
 				{
 					String name = n.Val.Value;
-					if (name != s.StyleId) knownStyles[name] = s;
+					if (name != s.StyleId) _knownStyles[name] = s;
 				}
 
-				knownStyles.Add(s.StyleId, s);
+				_knownStyles.Add(s.StyleId, s);
 			}
 		}
 
@@ -97,12 +97,12 @@ namespace HtmlToOpenXml
 			// We will try to find the styles another time with case-insensitive:
 			if (ignoreCase)
 			{
-				if (!knownStyles.TryGetValueIgnoreCase(name, styleType, out style))
+				if (!_knownStyles.TryGetValueIgnoreCase(name, styleType, out style))
 				{
 					if (StyleMissing != null)
 					{
-						StyleMissing(this, new StyleEventArgs(name, mainPart, styleType));
-						if (knownStyles.TryGetValueIgnoreCase(name, styleType, out style))
+						StyleMissing(this, new StyleEventArgs(name, _mainPart, styleType));
+						if (_knownStyles.TryGetValueIgnoreCase(name, styleType, out style))
 							return style.StyleId;
 					}
 					return null; // null means we ignore this style (css class)
@@ -112,11 +112,11 @@ namespace HtmlToOpenXml
 			}
 			else
 			{
-				if (!knownStyles.TryGetValue(name, out style))
+				if (!_knownStyles.TryGetValue(name, out style))
 				{
 					if (!EnsureKnownStyle(name, out style))
 					{
-						StyleMissing?.Invoke(this, new StyleEventArgs(name, mainPart, styleType));
+						StyleMissing?.Invoke(this, new StyleEventArgs(name, _mainPart, styleType));
 						return name;
 					}
 				}
@@ -139,7 +139,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool DoesStyleExists(string name)
 		{
-			return knownStyles.ContainsKey(name);
+			return _knownStyles.ContainsKey(name);
 		}
 
 		#endregion
@@ -151,10 +151,10 @@ namespace HtmlToOpenXml
 		/// </summary>
 		internal void AddStyle(String name, Style style)
 		{
-			knownStyles[name] = style;
-			if (mainPart.StyleDefinitionsPart == null)
-				mainPart.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
-			mainPart.StyleDefinitionsPart.Styles.Append(style);
+			_knownStyles[name] = style;
+			if (_mainPart.StyleDefinitionsPart == null)
+				_mainPart.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+			_mainPart.StyleDefinitionsPart.Styles.Append(style);
 		}
 
 		#endregion
@@ -181,23 +181,23 @@ namespace HtmlToOpenXml
 		internal RunStyleCollection Runs
 		{
 			[System.Diagnostics.DebuggerHidden()]
-			get { return runStyle; }
+			get { return _runStyle; }
 		}
 		internal TableStyleCollection Tables
 		{
 			[System.Diagnostics.DebuggerHidden()]
-			get { return tableStyle; }
+			get { return _tableStyle; }
 		}
 		internal ParagraphStyleCollection Paragraph
 		{
 			[System.Diagnostics.DebuggerHidden()]
-			get { return paraStyle; }
+			get { return _paraStyle; }
 		}
         internal NumberingListStyleCollection NumberingList
         {
 			// use lazy loading to avoid injecting NumberListDefinition if not required
             [System.Diagnostics.DebuggerHidden()]
-            get { return listStyle ?? (listStyle = new NumberingListStyleCollection(mainPart)); }
+            get { return _listStyle ?? (_listStyle = new NumberingListStyleCollection(_mainPart)); }
         }
 
 		//____________________________________________________________________

--- a/src/Html2OpenXml/HtmlEnumerator.cs
+++ b/src/Html2OpenXml/HtmlEnumerator.cs
@@ -22,11 +22,11 @@ namespace HtmlToOpenXml
 	sealed class HtmlEnumerator : IEnumerator<String>
 	{
 		private static Regex
-            stripTagRegex = new Regex(@"(</?\w+)");          // extract the name of a tag without its attributes but with the < >
+            _stripTagRegex = new Regex(@"(</?\w+)");          // extract the name of a tag without its attributes but with the < >
 
-		private IEnumerator<String> en;
-		private String current, currentTag;
-		private HtmlAttributeCollection attributes, styleAttributes;
+		private IEnumerator<String> _en;
+		private String _current, _currentTag;
+		private HtmlAttributeCollection _attributes, _styleAttributes;
 
 
 		/// <summary>
@@ -63,12 +63,12 @@ namespace HtmlToOpenXml
 			// Split our html using the tags
 			String[] lines = Regex.Split(html, @"(</?\w+[^>]*/?>)", RegexOptions.Singleline);
 
-			this.en = (lines as IEnumerable<String>).GetEnumerator();
+			this._en = (lines as IEnumerable<String>).GetEnumerator();
 		}
 
 		public void Dispose()
 		{
-			en.Dispose();
+			_en.Dispose();
 		}
 
 		//__________________________________________________________________________
@@ -120,7 +120,7 @@ namespace HtmlToOpenXml
 
 		public void Reset()
 		{
-			en.Reset();
+			_en.Reset();
 		}
 
 		/// <summary>
@@ -134,15 +134,15 @@ namespace HtmlToOpenXml
 		/// </returns>
 		public bool MoveUntilMatch(String tag)
 		{
-			current = currentTag = null;
-			attributes = styleAttributes = null;
+			_current = _currentTag = null;
+			_attributes = _styleAttributes = null;
 			bool success;
 
 			// Ignore empty lines
-			while ((success = en.MoveNext()) && (current = en.Current.Trim('\r', '\n')).Length == 0) ;
+			while ((success = _en.MoveNext()) && (_current = _en.Current.Trim('\r', '\n')).Length == 0) ;
 
 			if (success && tag != null)
-				return !current.Equals(tag, StringComparison.CurrentCultureIgnoreCase);
+				return !_current.Equals(tag, StringComparison.CurrentCultureIgnoreCase);
 
 			return success;
 		}
@@ -157,7 +157,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public HtmlAttributeCollection StyleAttributes
 		{
-			get { return styleAttributes ?? (styleAttributes = HtmlAttributeCollection.ParseStyle(this.Attributes["style"])); }
+			get { return _styleAttributes ?? (_styleAttributes = HtmlAttributeCollection.ParseStyle(this.Attributes["style"])); }
 		}
 
 		/// <summary>
@@ -165,7 +165,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public HtmlAttributeCollection Attributes
 		{
-			get { return attributes ?? (attributes = HtmlAttributeCollection.Parse(current)); }
+			get { return _attributes ?? (_attributes = HtmlAttributeCollection.Parse(_current)); }
 		}
 
 		/// <summary>
@@ -173,9 +173,9 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool IsCurrentHtmlTag
 		{
-			get { return current[0] == '<' 
+			get { return _current[0] == '<' 
 				// ensure we have not match a false tag like '< p >' nor '<3'
-				&& current.Length > 1 && (char.IsLetter(current[1]) || current[1] == '/'); }
+				&& _current.Length > 1 && (char.IsLetter(_current[1]) || _current[1] == '/'); }
 		}
 
 		/// <summary>
@@ -183,7 +183,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool IsSelfClosedTag
 		{
-			get { return this.IsCurrentHtmlTag && current.EndsWith("/>", StringComparison.Ordinal); }
+			get { return this.IsCurrentHtmlTag && _current.EndsWith("/>", StringComparison.Ordinal); }
 		}
 
 		/// <summary>
@@ -193,12 +193,12 @@ namespace HtmlToOpenXml
 		{
 			get
 			{
-				if(currentTag == null)
+				if(_currentTag == null)
 				{
-					Match m = stripTagRegex.Match(current);
-					currentTag = m.Success ? m.Groups[1].Value + ">" : null;
+					Match m = _stripTagRegex.Match(_current);
+					_currentTag = m.Success ? m.Groups[1].Value + ">" : null;
 				}
-				return currentTag;
+				return _currentTag;
 			}
 		}
 
@@ -219,12 +219,12 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public String Current
 		{
-			get { return current; }
+			get { return _current; }
 		}
 
 		Object System.Collections.IEnumerator.Current
 		{
-			get { return current; }
+			get { return _current; }
 		}
 	}
 }

--- a/src/Html2OpenXml/IO/DataUri.cs
+++ b/src/Html2OpenXml/IO/DataUri.cs
@@ -21,7 +21,7 @@ namespace HtmlToOpenXml.IO
     [System.Diagnostics.DebuggerDisplay("{Mime,nq}")]
     public sealed class DataUri
     {
-        private readonly static Regex dataUriRegex = new Regex(
+        private readonly static Regex _dataUriRegex = new Regex(
                 @"data\:(?<mime>\w+/\w+)?(?:;charset=(?<charset>[a-zA-Z_0-9-]+))?(?<base64>;base64)?,(?<data>.*)",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -52,7 +52,7 @@ namespace HtmlToOpenXml.IO
 
             // We will stick for IE compliance for the moment...
 
-            Match match = dataUriRegex.Match(uri);
+            Match match = _dataUriRegex.Match(uri);
             result = null;
 
             if (!match.Success) return false;
@@ -121,7 +121,7 @@ namespace HtmlToOpenXml.IO
         /// </summary>
         public static bool IsWellFormed(string uri)
         {
-            return dataUriRegex.IsMatch(uri);
+            return _dataUriRegex.IsMatch(uri);
         }
 
         //____________________________________________________________________

--- a/src/Html2OpenXml/IO/DefaultWebRequest.cs
+++ b/src/Html2OpenXml/IO/DefaultWebRequest.cs
@@ -24,20 +24,20 @@ namespace HtmlToOpenXml.IO
     /// </summary>
     public class DefaultWebRequest : IWebRequest
     {
-        private static HashSet<string> SupportedProtocols = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        private static HashSet<string> _supportedProtocols = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             "http", "https", "file"
         };
-        private Uri baseImageUri;
-        private static readonly HttpClient DefaultHttp = new HttpClient(new HttpClientHandler() {
+        private Uri _baseImageUri;
+        private static readonly HttpClient _defaultHttp = new HttpClient(new HttpClientHandler() {
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
         });
-        private readonly HttpClient httpClient;
+        private readonly HttpClient _httpClient;
 
 
         /// <summary>
         /// Initialize a new instance of the <see cref="DefaultWebRequest"/> class.
         /// </summary>
-        public DefaultWebRequest() : this(DefaultHttp) { }
+        public DefaultWebRequest() : this(_defaultHttp) { }
 
         /// <summary>
         /// Initialize a new instance of the <see cref="DefaultWebRequest"/> class with
@@ -46,8 +46,8 @@ namespace HtmlToOpenXml.IO
         /// <param name="httpClient">The HTTP client to use to download remote resources.</param>
         public DefaultWebRequest(HttpClient httpClient)
         {
-            this.httpClient = httpClient ?? DefaultHttp;
-            this.httpClient.DefaultRequestHeaders.AcceptEncoding.ParseAdd("gzip, deflate");
+            this._httpClient = httpClient ?? _defaultHttp;
+            this._httpClient.DefaultRequestHeaders.AcceptEncoding.ParseAdd("gzip, deflate");
         }
 
         /// <inheritdoc/>
@@ -103,7 +103,7 @@ namespace HtmlToOpenXml.IO
 
             try
             {
-                var response = await httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+                var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
                 if (response == null) return null;
                 resource.StatusCode = response.StatusCode;
 
@@ -125,7 +125,7 @@ namespace HtmlToOpenXml.IO
 
         /// <inheritdoc/>
         public virtual bool SupportsProtocol(string protocol)
-            => SupportedProtocols.Contains(protocol);
+            => _supportedProtocols.Contains(protocol);
 
         /// <summary>
         /// Gets or sets the base Uri used to automaticaly resolve relative images 
@@ -133,7 +133,7 @@ namespace HtmlToOpenXml.IO
         /// </summary>
         public Uri BaseImageUrl
         {
-            get { return this.baseImageUri; }
+            get { return this._baseImageUri; }
             set
             {
                 if (value != null)
@@ -146,7 +146,7 @@ namespace HtmlToOpenXml.IO
                     if (value.IsFile && value.LocalPath[value.LocalPath.Length - 1] != '/')
                         value = new Uri(value.OriginalString + '/');
                 }
-                this.baseImageUri = value;
+                this._baseImageUri = value;
             }
         }
     }

--- a/src/Html2OpenXml/IO/ImageHeader.cs
+++ b/src/Html2OpenXml/IO/ImageHeader.cs
@@ -31,19 +31,19 @@ namespace HtmlToOpenXml.IO
 
         public enum FileType { Unrecognized, Bitmap, Gif, Png, Jpeg, Emf }
 
-        private static readonly byte[] pngSignatureBytes = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        private static readonly byte[] _pngSignatureBytes = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 
-        private static Dictionary<byte[], FileType> imageFormatDecoders = new Dictionary<byte[], FileType>()
+        private static Dictionary<byte[], FileType> _imageFormatDecoders = new Dictionary<byte[], FileType>()
         {
             { new byte[] { 0x42, 0x4D }, FileType.Bitmap },
             { Encoding.UTF8.GetBytes("GIF87a"), FileType.Gif },
             { Encoding.UTF8.GetBytes("GIF89a"), FileType.Gif }, // animated gif
-            { pngSignatureBytes, FileType.Png },
+            { _pngSignatureBytes, FileType.Png },
             { new byte[] { 0xff, 0xd8 }, FileType.Jpeg },
             { new byte[] { 0x1, 0, 0, 0 }, FileType.Emf }
         };
 
-        private static readonly int MaxMagicBytesLength = imageFormatDecoders
+        private static readonly int _maxMagicBytesLength = _imageFormatDecoders
             .Keys.OrderByDescending(x => x.Length).First().Length;
 
 
@@ -117,11 +117,11 @@ namespace HtmlToOpenXml.IO
         /// </summary>
         private static FileType DetectFileType (SequentialBinaryReader reader)
         {
-            byte[] magicBytes = new byte[MaxMagicBytesLength];
-            for (int i = 0; i < MaxMagicBytesLength; i += 1)
+            byte[] magicBytes = new byte[_maxMagicBytesLength];
+            for (int i = 0; i < _maxMagicBytesLength; i += 1)
             {
                 magicBytes[i] = reader.ReadByte();
-                foreach (var kvPair in imageFormatDecoders)
+                foreach (var kvPair in _imageFormatDecoders)
                 {
                     if (StartsWith(magicBytes, kvPair.Key))
                     {
@@ -239,7 +239,7 @@ namespace HtmlToOpenXml.IO
         private static Size DecodePng(SequentialBinaryReader reader)
         {
             reader.IsBigEndian = true;
-            reader.ReadBytes(pngSignatureBytes.Length);
+            reader.ReadBytes(_pngSignatureBytes.Length);
             reader.Skip(8);
 
             int width = reader.ReadInt32();

--- a/src/Html2OpenXml/PredefinedStyles.cs
+++ b/src/Html2OpenXml/PredefinedStyles.cs
@@ -8,7 +8,7 @@ namespace HtmlToOpenXml
     /// </summary>
     internal class PredefinedStyles
     {
-        private static global::System.Resources.ResourceManager resourceMan;
+        private static global::System.Resources.ResourceManager _resourceMan;
 
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace HtmlToOpenXml
         {
             get
             {
-                if (object.ReferenceEquals(resourceMan, null))
+                if (object.ReferenceEquals(_resourceMan, null))
                 {
                     ResourceManager temp = new ResourceManager("HtmlToOpenXml.PredefinedStyles",
 #if !NETSTANDARD1_3
@@ -36,9 +36,9 @@ namespace HtmlToOpenXml
 #else
             typeof(PredefinedStyles).GetTypeInfo().Assembly);
 #endif
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
     }

--- a/src/Html2OpenXml/Primitives/HtmlBorder.cs
+++ b/src/Html2OpenXml/Primitives/HtmlBorder.cs
@@ -24,18 +24,18 @@ namespace HtmlToOpenXml
 	/// </summary>
 	struct HtmlBorder
 	{
-		private SideBorder[] sides;
+		private SideBorder[] _sides;
 
 
 		public HtmlBorder(SideBorder all)
 		{
-			if (!all.IsValid) sides = null;
-			else this.sides = new[] { all, all, all, all };
+			if (!all.IsValid) _sides = null;
+			else this._sides = new[] { all, all, all, all };
 		}
 
 		private void EnsureSides()
 		{
-			if(this.sides == null) sides = new SideBorder[4];
+			if(this._sides == null) _sides = new SideBorder[4];
 		}
 
 		//____________________________________________________________________
@@ -46,8 +46,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public SideBorder Bottom
 		{
-			get { return sides == null ? SideBorder.Empty : sides[2]; }
-			set { EnsureSides(); sides[2] = value; }
+			get { return _sides == null ? SideBorder.Empty : _sides[2]; }
+			set { EnsureSides(); _sides[2] = value; }
 		}
 
 		/// <summary>
@@ -55,8 +55,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public SideBorder Left
 		{
-			get { return sides == null ? SideBorder.Empty : sides[3]; }
-			set { EnsureSides(); sides[3] = value; }
+			get { return _sides == null ? SideBorder.Empty : _sides[3]; }
+			set { EnsureSides(); _sides[3] = value; }
 		}
 
 		/// <summary>
@@ -64,8 +64,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public SideBorder Top
 		{
-			get { return sides == null ? SideBorder.Empty : sides[0]; }
-			set { EnsureSides(); sides[0] = value; }
+			get { return _sides == null ? SideBorder.Empty : _sides[0]; }
+			set { EnsureSides(); _sides[0] = value; }
 		}
 
 		/// <summary>
@@ -73,8 +73,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public SideBorder Right
 		{
-			get { return sides == null ? SideBorder.Empty : sides[1]; }
-			set { EnsureSides(); sides[1] = value; }
+			get { return _sides == null ? SideBorder.Empty : _sides[1]; }
+			set { EnsureSides(); _sides[1] = value; }
 		}
 
 		/// <summary>
@@ -82,7 +82,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool IsEmpty
 		{
-			get { return sides == null || !(Left.IsValid || Right.IsValid || Bottom.IsValid || Top.IsValid); }
+			get { return _sides == null || !(Left.IsValid || Right.IsValid || Bottom.IsValid || Top.IsValid); }
 		}
 	}
 }

--- a/src/Html2OpenXml/Primitives/HtmlColor.cs
+++ b/src/Html2OpenXml/Primitives/HtmlColor.cs
@@ -19,7 +19,7 @@ namespace HtmlToOpenXml
     /// </summary>
     struct HtmlColor
     {
-        private static readonly char[] hexDigits = {
+        private static readonly char[] _hexDigits = {
          '0', '1', '2', '3', '4', '5', '6', '7',
          '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
@@ -254,8 +254,8 @@ namespace HtmlToOpenXml
             for (int i = 0; i < bytes.Length; i++)
             {
                 int b = bytes[i];
-                chars[i * 2] = hexDigits[b >> 4];
-                chars[i * 2 + 1] = hexDigits[b & 0xF];
+                chars[i * 2] = _hexDigits[b >> 4];
+                chars[i * 2 + 1] = _hexDigits[b & 0xF];
             }
             return new string(chars);
         }

--- a/src/Html2OpenXml/Primitives/HtmlFont.cs
+++ b/src/Html2OpenXml/Primitives/HtmlFont.cs
@@ -21,20 +21,20 @@ namespace HtmlToOpenXml
 		/// <summary>Represents an empty font (not defined).</summary>
 		public static readonly HtmlFont Empty = new HtmlFont(FontStyle.Normal, FontVariant.Normal, FontWeight.Normal, Unit.Empty, null);
 
-		private FontStyle style;
-		private FontVariant variant;
-		private string family;
-		private FontWeight weight;
-		private Unit size;
+		private FontStyle _style;
+		private FontVariant _variant;
+		private string _family;
+		private FontWeight _weight;
+		private Unit _size;
 
 
 		public HtmlFont(FontStyle style, FontVariant variant, FontWeight weight, Unit size, string family)
 		{
-			this.style = style;
-			this.variant = variant;
-			this.family = family;
-			this.weight = weight;
-			this.size = size;
+			this._style = style;
+			this._variant = variant;
+			this._family = family;
+			this._weight = weight;
+			this._size = size;
 		}
 
 		public static HtmlFont Parse(String str)
@@ -59,30 +59,30 @@ namespace HtmlToOpenXml
 			if (fontParts.Length == 2) // 2=the minimal set of required parameters
 			{
 				// should be the size and the family (in that order). Others are set to their default values
-				font.size = ReadFontSize(fontParts[0]);
-				if (!font.size.IsValid) return HtmlFont.Empty;
-				font.family = Converter.ToFontFamily(fontParts[1]);
+				font._size = ReadFontSize(fontParts[0]);
+				if (!font._size.IsValid) return HtmlFont.Empty;
+				font._family = Converter.ToFontFamily(fontParts[1]);
 				return font;
 			}
 
 			int index = 0;
 
 			FontStyle? style = Converter.ToFontStyle(fontParts[index]);
-			if (style.HasValue) { font.style = style.Value; index++; }
+			if (style.HasValue) { font._style = style.Value; index++; }
 
 			if (index + 2 > fontParts.Length) return HtmlFont.Empty;
 			FontVariant? variant = Converter.ToFontVariant(fontParts[index]);
-			if (variant.HasValue) { font.variant = variant.Value; index++; }
+			if (variant.HasValue) { font._variant = variant.Value; index++; }
 
 			if (index + 2 > fontParts.Length) return HtmlFont.Empty;
 			FontWeight? weight = Converter.ToFontWeight(fontParts[index]);
-			if (weight.HasValue) { font.weight = weight.Value; index++; }
+			if (weight.HasValue) { font._weight = weight.Value; index++; }
 
 			if (fontParts.Length - index < 2) return HtmlFont.Empty;
-			font.size = ReadFontSize(fontParts[fontParts.Length - 2]);
-			if (!font.size.IsValid) return HtmlFont.Empty;
+			font._size = ReadFontSize(fontParts[fontParts.Length - 2]);
+			if (!font._size.IsValid) return HtmlFont.Empty;
 
-			font.family = Converter.ToFontFamily(fontParts[fontParts.Length - 1]);
+			font._family = Converter.ToFontFamily(fontParts[fontParts.Length - 1]);
 
 			return font;
 		}
@@ -101,8 +101,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public string Family
 		{
-			get { return family; }
-			set { family = value; }
+			get { return _family; }
+			set { _family = value; }
 		}
 
 		/// <summary>
@@ -110,8 +110,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public FontStyle Style
 		{
-			get { return style; }
-			set { style = value; }
+			get { return _style; }
+			set { _style = value; }
 		}
 
 		/// <summary>
@@ -119,8 +119,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public FontVariant Variant
 		{
-			get { return variant; }
-			set { variant = value; }
+			get { return _variant; }
+			set { _variant = value; }
 		}
 
 		/// <summary>
@@ -128,8 +128,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public Unit Size
 		{
-			get { return size; }
-			set { size = value; }
+			get { return _size; }
+			set { _size = value; }
 		}
 
 		/// <summary>
@@ -137,8 +137,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public FontWeight Weight
 		{
-			get { return weight; }
-			set { weight = value; }
+			get { return _weight; }
+			set { _weight = value; }
 		}
 
 		/// <summary>
@@ -146,7 +146,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool IsEmpty
 		{
-			get { return family == null && !size.IsValid && weight == FontWeight.Normal && style == FontStyle.Normal && variant == FontVariant.Normal; }
+			get { return _family == null && !_size.IsValid && _weight == FontWeight.Normal && _style == FontStyle.Normal && _variant == FontVariant.Normal; }
 		}
 	}
 }

--- a/src/Html2OpenXml/Primitives/Margin.cs
+++ b/src/Html2OpenXml/Primitives/Margin.cs
@@ -20,12 +20,12 @@ namespace HtmlToOpenXml
     /// </summary>
     struct Margin
     {
-        private Unit[] sides;
+        private Unit[] _sides;
 
 
         public Margin(Unit top, Unit right, Unit bottom, Unit left)
         {
-            this.sides = new[] { top, right, bottom, left };
+            this._sides = new[] { top, right, bottom, left };
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace HtmlToOpenXml
 
 		private void EnsureSides()
 		{
-			if (this.sides == null) sides = new Unit[4];
+			if (this._sides == null) _sides = new Unit[4];
 		}
 
         //____________________________________________________________________
@@ -102,8 +102,8 @@ namespace HtmlToOpenXml
         /// </summary>
         public Unit Bottom
         {
-            get { return sides == null ? Unit.Empty : sides[2]; }
-			set { EnsureSides(); sides[2] = value; }
+            get { return _sides == null ? Unit.Empty : _sides[2]; }
+			set { EnsureSides(); _sides[2] = value; }
         }
 
         /// <summary>
@@ -111,8 +111,8 @@ namespace HtmlToOpenXml
         /// </summary>
         public Unit Left
         {
-			get { return sides == null ? Unit.Empty : sides[3]; }
-			set { EnsureSides(); sides[3] = value; }
+			get { return _sides == null ? Unit.Empty : _sides[3]; }
+			set { EnsureSides(); _sides[3] = value; }
         }
 
         /// <summary>
@@ -120,8 +120,8 @@ namespace HtmlToOpenXml
         /// </summary>
         public Unit Top
         {
-			get { return sides == null ? Unit.Empty : sides[0]; }
-			set { EnsureSides(); sides[0] = value; }
+			get { return _sides == null ? Unit.Empty : _sides[0]; }
+			set { EnsureSides(); _sides[0] = value; }
         }
 
         /// <summary>
@@ -129,13 +129,13 @@ namespace HtmlToOpenXml
         /// </summary>
         public Unit Right
         {
-			get { return sides == null ? Unit.Empty : sides[1]; }
-			set { EnsureSides(); sides[1] = value; }
+			get { return _sides == null ? Unit.Empty : _sides[1]; }
+			set { EnsureSides(); _sides[1] = value; }
         }
 
         public bool IsValid
         {
-            get { return sides != null && Left.IsValid && Right.IsValid && Bottom.IsValid && Top.IsValid; }
+            get { return _sides != null && Left.IsValid && Right.IsValid && Bottom.IsValid && Top.IsValid; }
         }
 
 		/// <summary>
@@ -143,7 +143,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public bool IsEmpty
 		{
-			get { return sides == null || !(Left.IsValid || Right.IsValid || Bottom.IsValid || Top.IsValid); }
+			get { return _sides == null || !(Left.IsValid || Right.IsValid || Bottom.IsValid || Top.IsValid); }
 		}
     }
 }

--- a/src/Html2OpenXml/Primitives/SideBorder.cs
+++ b/src/Html2OpenXml/Primitives/SideBorder.cs
@@ -27,16 +27,16 @@ namespace HtmlToOpenXml
 		/// <summary>Represents an empty border (not defined).</summary>
 		public static readonly SideBorder Empty = new SideBorder();
 
-		private w.BorderValues style;
-		private HtmlColor color;
-		private Unit size;
+		private w.BorderValues _style;
+		private HtmlColor _color;
+		private Unit _size;
 
 
 		public SideBorder(w.BorderValues style, HtmlColor color, Unit size)
 		{
-			this.style = style;
-			this.color = color;
-			this.size = size;
+			this._style = style;
+			this._color = color;
+			this._size = size;
 		}
 
 		public static SideBorder Parse(String str)
@@ -120,8 +120,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public w.BorderValues Style
 		{
-			get { return style; }
-			set { style = value; }
+			get { return _style; }
+			set { _style = value; }
 		}
 
 		/// <summary>
@@ -129,8 +129,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public HtmlColor Color
 		{
-			get { return color; }
-			set { color = value; }
+			get { return _color; }
+			set { _color = value; }
 		}
 
 		/// <summary>
@@ -138,8 +138,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public Unit Width
 		{
-			get { return size; }
-			set { size = value; }
+			get { return _size; }
+			set { _size = value; }
 		}
 
 		/// <summary>
@@ -150,7 +150,7 @@ namespace HtmlToOpenXml
 			get { return this.Style != w.BorderValues.Nil; }
 		}
 
-		private string DebuggerDisplay
+		private string _debuggerDisplay
 		{
 			get { return String.Format(CultureInfo.InvariantCulture, "{{Border={0} {1} {2}}}", Style, Width.DebuggerDisplay, Color); }
 		}

--- a/src/Html2OpenXml/Primitives/Unit.cs
+++ b/src/Html2OpenXml/Primitives/Unit.cs
@@ -26,15 +26,15 @@ namespace HtmlToOpenXml
         public static readonly Unit Auto = new Unit(UnitMetric.Auto, 0L);
 
 		private UnitMetric type;
-		private double value;
-		private long valueInEmus;
+		private double _value;
+		private long _valueInEmus;
 
 
 		public Unit(UnitMetric type, Double value)
 		{
 			this.type = type;
-			this.value = value;
-			this.valueInEmus = ComputeInEmus(type, value);
+			this._value = value;
+			this._valueInEmus = ComputeInEmus(type, value);
 		}
 
 		public static Unit Parse(String str)
@@ -139,7 +139,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public Double Value
 		{
-			get { return value; }
+			get { return _value; }
 		}
 
 		/// <summary>
@@ -147,7 +147,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public Int64 ValueInEmus
 		{
-			get { return valueInEmus; }
+			get { return _valueInEmus; }
 		}
 
 		/// <summary>
@@ -155,7 +155,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public Int64 ValueInDxa
 		{
-			get { return (long) (((double) valueInEmus / 914400L) * 20 * 72); }
+			get { return (long) (((double) _valueInEmus / 914400L) * 20 * 72); }
 		}
 
 		/// <summary>
@@ -163,7 +163,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public int ValueInPx
 		{
-			get { return (int) (type == UnitMetric.Pixel ? this.value : (float) valueInEmus / 914400L * 96); }
+			get { return (int) (type == UnitMetric.Pixel ? this._value : (float) _valueInEmus / 914400L * 96); }
 		}
 
 		/// <summary>
@@ -171,7 +171,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public int ValueInPoint
 		{
-			get { return (int) (type == UnitMetric.Point ? this.value : (float) valueInEmus / 12700L); }
+			get { return (int) (type == UnitMetric.Point ? this._value : (float) _valueInEmus / 12700L); }
 		}
 
 		/// <summary>

--- a/src/Html2OpenXml/Utilities/HtmlColorTranslator.cs
+++ b/src/Html2OpenXml/Utilities/HtmlColorTranslator.cs
@@ -8,12 +8,12 @@ namespace HtmlToOpenXml
     /// </summary>
     static class HtmlColorTranslator
     {
-        private static readonly Dictionary<string, HtmlColor> namedColors = InitKnownColors();
+        private static readonly Dictionary<string, HtmlColor> _namedColors = InitKnownColors();
 
         public static HtmlColor FromHtml (string htmlColor)
         {
             HtmlColor color = HtmlColor.Empty;
-            namedColors.TryGetValue(htmlColor, out color);
+            _namedColors.TryGetValue(htmlColor, out color);
             return color;
         }
 

--- a/src/Html2OpenXml/Utilities/HttpUtility.cs
+++ b/src/Html2OpenXml/Utilities/HttpUtility.cs
@@ -27,7 +27,7 @@ namespace HtmlToOpenXml
 
 		static class HtmlEntities
 		{
-			private static string[] entitiesList = new string[] { 
+			private static string[] _entitiesList = new string[] { 
 				"\"-quot", "&-amp", "<-lt", ">-gt", "\x00a0-nbsp", "\x00a1-iexcl", "\x00a2-cent", "\x00a3-pound", "\x00a4-curren", "\x00a5-yen", "\x00a6-brvbar", "\x00a7-sect", "\x00a8-uml", "\x00a9-copy", "\x00aa-ordf", "\x00ab-laquo", 
 				"\x00ac-not", "\x00ad-shy", "\x00ae-reg", "\x00af-macr", "\x00b0-deg", "\x00b1-plusmn", "\x00b2-sup2", "\x00b3-sup3", "\x00b4-acute", "\x00b5-micro", "\x00b6-para", "\x00b7-middot", "\x00b8-cedil", "\x00b9-sup1", "\x00ba-ordm", "\x00bb-raquo", 
 				"\x00bc-frac14", "\x00bd-frac12", "\x00be-frac34", "\x00bf-iquest", "\x00c0-Agrave", "\x00c1-Aacute", "\x00c2-Acirc", "\x00c3-Atilde", "\x00c4-Auml", "\x00c5-Aring", "\x00c6-AElig", "\x00c7-Ccedil", "\x00c8-Egrave", "\x00c9-Eacute", "\x00ca-Ecirc", "\x00cb-Euml", 
@@ -45,28 +45,28 @@ namespace HtmlToOpenXml
 				"∴-there4", "∼-sim", "≅-cong", "≈-asymp", "≠-ne", "≡-equiv", "≤-le", "≥-ge", "⊂-sub", "⊃-sup", "⊄-nsub", "⊆-sube", "⊇-supe", "⊕-oplus", "⊗-otimes", "⊥-perp", 
 				"⋅-sdot", "⌈-lceil", "⌉-rceil", "⌊-lfloor", "⌋-rfloor", "〈-lang", "〉-rang", "◊-loz", "♠-spades", "♣-clubs", "♥-hearts", "♦-diams"
 			 };
-			private static Dictionary<String,Char> entitiesLookupTable;
-			private static readonly object SyncObject = new object();
+			private static Dictionary<String,Char> _entitiesLookupTable;
+			private static readonly object _syncObject = new object();
 
 			internal static char Lookup(string entity)
 			{
-				if (entitiesLookupTable == null)
+				if (_entitiesLookupTable == null)
 				{
-					lock (SyncObject)
+					lock (_syncObject)
 					{
-						if (entitiesLookupTable == null)
+						if (_entitiesLookupTable == null)
 						{
-							Dictionary<String, Char> hashtable = new Dictionary<String, Char>(entitiesList.Length);
-							foreach (string str in entitiesList)
+							Dictionary<String, Char> hashtable = new Dictionary<String, Char>(_entitiesList.Length);
+							foreach (string str in _entitiesList)
 								hashtable[str.Substring(2)] = str[0];
 
-							entitiesLookupTable = hashtable;
+							_entitiesLookupTable = hashtable;
 						}
 					}
 				}
 
 				char ch;
-				if (!entitiesLookupTable.TryGetValue(entity, out ch)) return '\0';
+				if (!_entitiesLookupTable.TryGetValue(entity, out ch)) return '\0';
 				return ch;
 			}
 		}

--- a/src/Html2OpenXml/Utilities/Logging.cs
+++ b/src/Html2OpenXml/Utilities/Logging.cs
@@ -20,9 +20,9 @@ namespace HtmlToOpenXml
     /// </summary>
     static class Logging
 	{
-		private const string TraceSourceName = "html2openxml";
-		private static TraceSource traceSource;
-		private static bool enabled;
+		private const string _traceSourceName = "html2openxml";
+		private static TraceSource _traceSource;
+		private static bool _enabled;
 
 
 		static Logging()
@@ -74,8 +74,8 @@ namespace HtmlToOpenXml
 		private static void Initialize()
 		{
 #if NETSTANDARD1_3 || NETSTANDARD2_0
-            traceSource = new TraceSource(TraceSourceName);
-			enabled = traceSource.Switch.Level != SourceLevels.Off;
+            _traceSource = new TraceSource(_traceSourceName);
+			_enabled = _traceSource.Switch.Level != SourceLevels.Off;
 #else
             try
 			{
@@ -107,7 +107,7 @@ namespace HtmlToOpenXml
 		private static void PrintLine(TraceEventType eventType, int id, string msg)
 		{
 			if (!ValidateSettings(eventType)) return;
-			traceSource.TraceEvent(eventType, id, msg);
+			_traceSource.TraceEvent(eventType, id, msg);
 		}
 
         #endregion
@@ -119,8 +119,8 @@ namespace HtmlToOpenXml
 		/// </summary>
 		private static void OnDomainUnload(object sender, EventArgs e)
 		{
-			traceSource.Close();
-			enabled = false;
+			_traceSource.Close();
+			_enabled = false;
 		}
 
         #endregion
@@ -132,9 +132,9 @@ namespace HtmlToOpenXml
 		/// </summary>
 		private static bool ValidateSettings(TraceEventType traceLevel)
 		{
-			if (!enabled) return false;
+			if (!_enabled) return false;
 
-			if (traceSource == null || !traceSource.Switch.ShouldTrace(traceLevel))
+			if (_traceSource == null || !_traceSource.Switch.ShouldTrace(traceLevel))
 				return false;
 
 			return true;
@@ -150,7 +150,7 @@ namespace HtmlToOpenXml
 		/// </summary>
 		public static bool On
 		{
-			get { return enabled; }
+			get { return _enabled; }
 		}
 	}
 }

--- a/test/HtmlToOpenXml.Tests/HtmlConverterTestBase.cs
+++ b/test/HtmlToOpenXml.Tests/HtmlConverterTestBase.cs
@@ -7,8 +7,8 @@ namespace HtmlToOpenXml.Tests
 {
     public abstract class HtmlConverterTestBase
     {
-        private System.IO.MemoryStream generatedDocument;
-        private WordprocessingDocument package;
+        private System.IO.MemoryStream _generatedDocument;
+        private WordprocessingDocument _package;
 
         protected HtmlConverter converter;
         protected MainDocumentPart mainPart;
@@ -17,13 +17,13 @@ namespace HtmlToOpenXml.Tests
         [SetUp]
         public void Init ()
         {
-            generatedDocument = new System.IO.MemoryStream();
-            package = WordprocessingDocument.Create(generatedDocument, WordprocessingDocumentType.Document);
+            _generatedDocument = new System.IO.MemoryStream();
+            _package = WordprocessingDocument.Create(_generatedDocument, WordprocessingDocumentType.Document);
 
-            mainPart = package.MainDocumentPart;
+            mainPart = _package.MainDocumentPart;
             if (mainPart == null)
             {
-                mainPart = package.AddMainDocumentPart();
+                mainPart = _package.AddMainDocumentPart();
                 new Document(new Body()).Save(mainPart);
             }
 
@@ -33,8 +33,8 @@ namespace HtmlToOpenXml.Tests
         [TearDown]
         public void Close ()
         {
-            package?.Dispose();
-            generatedDocument?.Dispose();
+            _package?.Dispose();
+            _generatedDocument?.Dispose();
         }
     }
 }

--- a/test/HtmlToOpenXml.Tests/Utilities/GenericTestCaseAttribute.cs
+++ b/test/HtmlToOpenXml.Tests/Utilities/GenericTestCaseAttribute.cs
@@ -14,18 +14,18 @@ namespace HtmlToOpenXml.Tests
     {
         // Code source from https://stackoverflow.com/questions/2364929/nunit-testcase-with-generics
 
-        private readonly Type type;
+        private readonly Type _type;
 
         public GenericTestCaseAttribute(Type type, params object[] arguments) : base(arguments)
         {
-            this.type = type;
+            this._type = type;
         }
 
         IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, Test suite)
         {
-            if (method.IsGenericMethodDefinition && type != null)
+            if (method.IsGenericMethodDefinition && _type != null)
             {
-                var gm = method.MakeGenericMethod(type);
+                var gm = method.MakeGenericMethod(_type);
                 return BuildFrom(gm, suite);
             }
             return BuildFrom(method, suite);


### PR DESCRIPTION
By the [microsoft documentation](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#camel-case), private fields should start with `_`(underscore) and should use camel case.