### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## vNext
+## 3.1.1
 
-- Support MathMl
-- Support SVG
+- Fix respecting layout with `div`/`p` ending with line break #158
+- Prevent crash when header/footer is incomplete and parsing image #159
+- Fix combining 2 runs separated by a break, 2nd line should not be prefixed by a space
 
 ## 3.1.0
 
@@ -12,6 +13,13 @@
 - Support property line-height #52
 - Fallback to `background` style attribute as many users use this simplified attribute version
 - In `HtmlDomExpression.CreateFromHtmlNode`, use the correct casting to `IElement` rather than `IHtmlElement`, to prevent crash if `svg` node is encountered
+
+## 3.0.1
+
+- Ensure to count existing images from header and footer too #113
+- Preserve line break pre for OSX/Windows
+- Prevent a crash when the provided style is missing its type
+- Defensive code to avoid 2 rowSpan+colSpan with a cell in between to crash #59
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This library supports both **.Net Framework 4.6.2**, **.NET Standard 2.0** and *
 
 Depends on [DocumentFormat.OpenXml](https://www.nuget.org/packages/DocumentFormat.OpenXml/) and [AngleSharp](https://www.nuget.org/packages/AngleSharp).
 
+-> [Official Nuget Package](https://www.nuget.org/packages/HtmlToOpenXml.dll)
+
 ## See Also
 
 * [Documentation](https://github.com/onizet/html2openxml/wiki)

--- a/src/Html2OpenXml/Expressions/BlockElementExpression.cs
+++ b/src/Html2OpenXml/Expressions/BlockElementExpression.cs
@@ -271,7 +271,7 @@ class BlockElementExpression(IHtmlElement node, params OpenXmlLeafElement[]? sty
                     runs.Add(element);
                     continue;
                 }
-                // if 2 tables are consectuives, we insert a paragraph in between
+                // if 2 tables are consecutives, we insert a paragraph in between
                 // or Word will merge the two tables
                 else if (element is Table && previousElement is Table)
                 {
@@ -309,6 +309,16 @@ class BlockElementExpression(IHtmlElement node, params OpenXmlLeafElement[]? sty
         context.CascadeStyles(p);
 
         p.Append(CombineRuns(runs));
+
+        // in Html, if a paragraph is ending with a line break, it is ignored
+        if (p.LastChild is Run run && run.LastChild is Break lineBreak)
+        {
+            // is this a standalone <br> inside the block? If so, replace the lineBreak with an empty paragraph
+            if (runs.Count == 1) run.Append(new Text());
+            if (run.ChildElements.Count == 1) run.Remove();
+            else lineBreak.Remove();
+        }
+
         return p;
     }
 

--- a/src/Html2OpenXml/Expressions/Image/ImageExpressionBase.cs
+++ b/src/Html2OpenXml/Expressions/Image/ImageExpressionBase.cs
@@ -87,8 +87,8 @@ abstract class ImageExpressionBase(AngleSharp.Dom.IElement node)  : HtmlDomExpre
 
             foreach (var part in new[] { 
                 context.MainPart.Document.Body!.Descendants<Drawing>(),
-                context.MainPart.HeaderParts.SelectMany(f => f.Header.Descendants<Drawing>()),
-                context.MainPart.FooterParts.SelectMany(f => f.Footer.Descendants<Drawing>())
+                context.MainPart.HeaderParts.Where(f => f.Header != null).SelectMany(f => f.Header.Descendants<Drawing>()),
+                context.MainPart.FooterParts.Where(f => f.Footer != null).SelectMany(f => f.Footer.Descendants<Drawing>())
             })
             foreach (Drawing d in part)
             {

--- a/src/Html2OpenXml/Expressions/PhrasingElementExpression.cs
+++ b/src/Html2OpenXml/Expressions/PhrasingElementExpression.cs
@@ -218,6 +218,10 @@ class PhrasingElementExpression(IHtmlElement node, OpenXmlLeafElement? styleProp
                 }
                 endsWithSpace = text[text.Length - 1].IsSpaceCharacter();
             }
+            else if (run.LastChild is Break)
+            {
+                endsWithSpace = true;
+            }
             yield return run;
         }
     }

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -9,13 +9,13 @@
     <AssemblyName>HtmlToOpenXml</AssemblyName>
     <RootNamespace>HtmlToOpenXml</RootNamespace>
     <PackageId>HtmlToOpenXml.dll</PackageId>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <PackageIcon>icon.png</PackageIcon>
     <Copyright>Copyright 2009-$([System.DateTime]::Now.Year) Olivier Nizet</Copyright>
     <PackageReleaseNotes>See changelog https://github.com/onizet/html2openxml/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>office openxml netcore html</PackageTags>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
+    <AssemblyVersion>3.1.1</AssemblyVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/onizet/html2openxml</PackageProjectUrl>
     <RepositoryUrl>https://github.com/onizet/html2openxml</RepositoryUrl>

--- a/test/HtmlToOpenXml.Tests/ElementTests.cs
+++ b/test/HtmlToOpenXml.Tests/ElementTests.cs
@@ -136,7 +136,7 @@ background:red;
         {
             var elements = converter.Parse(@"Lorem<br/>Ipsum");
             Assert.That(elements, Has.Count.EqualTo(1));
-            Assert.That(elements[0].ChildElements, Has.Count.EqualTo(4));
+            Assert.That(elements[0].ChildElements, Has.Count.EqualTo(3));
 
             Assert.Multiple(() =>
             {

--- a/test/HtmlToOpenXml.Tests/WhitespaceTests.cs
+++ b/test/HtmlToOpenXml.Tests/WhitespaceTests.cs
@@ -74,12 +74,28 @@ namespace HtmlToOpenXml.Tests
         }
 
         [Test(Description = "`nbsp` entities should not be collapsed")]
-        public void NonBreakingSpaceEntities_ReturnsPreserveedWhitespace()
+        public void NonBreakingSpaceEntities_ReturnsPreservedWhitespace()
         {
             var elements = converter.Parse("<h1>&nbsp;&nbsp; Hello      World!     </h1>");
             Assert.That(elements, Has.Count.EqualTo(1));
             Assert.That(elements, Has.All.TypeOf<Paragraph>());
             Assert.That(elements[0].InnerText, Is.EqualTo("   Hello World!"));
+        }
+
+        [Test(Description = "Consecutive runs separated by a break should not prefix the 2nd line with a space")]
+        public void ConsecutivePhrasingWithBreak_ReturnsSecondLineWithNoSpaces()
+        {
+            var elements = converter.Parse("<span>Hello<br><span>World</span></span>");
+            Assert.That(elements, Has.Count.EqualTo(1));
+            Assert.That(elements, Has.All.TypeOf<Paragraph>());
+            Assert.That(elements[0].InnerText, Is.EqualTo("HelloWorld"));
+            var runs = elements[0].Elements<Run>();
+            Assert.That(runs.Count(), Is.EqualTo(3));
+            Assert.Multiple(() => {
+                Assert.That(runs.ElementAt(1).LastChild, Is.TypeOf<Break>());
+                Assert.That(runs.ElementAt(2).FirstChild, Is.TypeOf<Text>());
+            });
+            Assert.That(((Text)runs.ElementAt(2).FirstChild).Text, Is.EqualTo("World"));
         }
     }
 }


### PR DESCRIPTION
- Fix respecting layout with `div`/`p` ending with line break #158
- Prevent crash when header/footer is incomplete and parsing image #159
- Fix combining 2 runs separated by a break, 2nd line should not be prefixed by a space