### PR TITLE
fix: PhrasingElementExpression.cs - check empty string in text element

### DIFF
--- a/src/Html2OpenXml/Expressions/PhrasingElementExpression.cs
+++ b/src/Html2OpenXml/Expressions/PhrasingElementExpression.cs
@@ -1,4 +1,4 @@
-/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
+﻿/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
  * 
  * This source is subject to the Microsoft Permissive License.
  * Please see the License.txt file for more information.
@@ -208,7 +208,7 @@ class PhrasingElementExpression(IHtmlElement node, OpenXmlLeafElement? styleProp
             // run can be also a hyperlink
             textElement ??= run.GetFirstChild<Run>()?.GetFirstChild<Text>();
 
-            if (textElement != null) // could be null when <br/>
+            if (textElement != null && !string.IsNullOrEmpty(textElement.Text)) // could be null when <br/>
             {
                 var text = textElement.Text;
                 // we know that the text cannot be empty because we skip them in TextExpression


### PR DESCRIPTION
I had an error while parsing some (admittedly wrong) html, like the following (I reduced to a minimal example)

`<span>  <div>   <br />   <div>    <span>Texte</span>   </div>  </div> </span>`

The error was : 

> Index was outside the bounds of the array

The submitted code fixed the issue without causing any apparent regression, but I must confess I don't have enough understanding of the internals to assure the modification is needed. I leave that to the appreciation of the reviewer. I figured that, as long as we access the string by index, we should check that it is not empty. My doubts are about what to do if the string is empty.