### PR TITLE
Fix nested lists and allow list style attribute

### DIFF
--- a/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
@@ -1,4 +1,4 @@
-/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
+﻿/* Copyright (C) Olivier Nizet https://github.com/onizet/html2openxml - All Rights Reserved
  * 
  * This source is subject to the Microsoft Permissive License.
  * Please see the License.txt file for more information.
@@ -143,7 +143,15 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
         int overrideLevelIndex = 0;
         var isOrderedTag = node.NodeName.Equals("ol", StringComparison.OrdinalIgnoreCase);
         var dir = node.GetTextDirection();
-        if (!instanceId.HasValue || context.Converter.ContinueNumbering == false)
+
+        // be sure to restart to 1 any nested ordered list
+        if (currentLevel > 0 && isOrderedTag)
+        {
+            instanceId = IncrementInstanceId(context, abstractNumId, isReusable: false);
+            overrideLevelIndex = currentLevel;
+            listContext = new ListContext(listStyle, abstractNumId, instanceId.Value, currentLevel + 1, dir);
+        }
+        else if (!instanceId.HasValue || context.Converter.ContinueNumbering == false)
         {
             // create a new instance of that list template
             instanceId = IncrementInstanceId(context, abstractNumId, isReusable: context.Converter.ContinueNumbering);
@@ -157,13 +165,6 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
         {
             instanceId = IncrementInstanceId(context, abstractNumId, isReusable: false);
             listContext =  new ListContext(listStyle, abstractNumId, instanceId.Value, 1, dir);
-        }
-        // be sure to restart to 1 any nested ordered list
-        else if (currentLevel > 0 && isOrderedTag)
-        {
-            instanceId = IncrementInstanceId(context, abstractNumId, isReusable: false);
-            overrideLevelIndex = currentLevel;
-            listContext = new ListContext(listStyle, abstractNumId, instanceId.Value, currentLevel + 1, dir);
         }
         else
         {
@@ -197,19 +198,38 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
     private static string GetListName(IElement listNode, string? parentName = null)
     {
         var styleAttributes = listNode.GetStyles();
+        bool orderedList = listNode.NodeName.Equals("ol", StringComparison.OrdinalIgnoreCase);
         string? type = styleAttributes["list-style-type"];
+
+        if(orderedList && string.IsNullOrEmpty(type))
+        {
+            type = ListTypeToListStyleType(listNode.GetAttribute("type"));
+        }
 
         if (string.IsNullOrEmpty(type) || !supportedListTypes.Contains(type!))
         {
             if (parentName != null && IsCascadingStyle(parentName))
                 return parentName!;
 
-            bool orderedList = listNode.NodeName.Equals("ol", StringComparison.OrdinalIgnoreCase);
             type = orderedList? "decimal" : "disc";
         }
 
         return type!;
     }
+
+    /// <summary>
+    /// Map ordered list style attribute values to css list-style-type.
+    /// Valid types are "1|a|A|i|I": https://w3schools.com/tags/att_ol_type.asp
+    /// </summary>
+    private static string? ListTypeToListStyleType(string? type) => type switch
+    {
+        "1" => "decimal",
+        "a" => "lower-alpha",
+        "A" => "upper-alpha",
+        "i" => "lower-roman",
+        "I" => "upper-roman",
+        _ => null
+    };
 
     /// <summary>
     /// Resolve the <see cref="ParagraphStyleId"/> of a list element node, 


### PR DESCRIPTION
Two fixes here:

The first is that nested ordered lists which changed to a different style would not reset numbering. eg:
1. 1
2. 2
    a. a
    b. b
3. 3
    a. a
    b. b

Would be put in the openxml as:
1. 1
2. 2
    a. a
    b. b
3. 3
    c. a
    d. b

Note how the nested alpha list does not reset numbering. The fix was just to reorder the if/else statements to give priority to restarting nested lists.

The second fix was support of the "type" attribute for the `<ol type="1|a|A|i|I">` tag (https://www.w3schools.com/tags/att_ol_type.asp).
I had some html which uses the type attribute rather than set the `style="list-style-type"` attribute.