### PR TITLE
Add a NumberedHeadingStyle option to DefaultStyles

### DIFF
--- a/src/Html2OpenXml/Primitives/DefaultStyles.cs
+++ b/src/Html2OpenXml/Primitives/DefaultStyles.cs
@@ -55,6 +55,13 @@ public class DefaultStyles
     public string HeadingStyle { get; set; } = PredefinedStyles.Heading;
 
     /// <summary>
+    /// Default style for numbered headings
+    /// Appends the level at the end of the style name
+    /// </summary>
+    /// <value>Heading</value>
+    public string NumberedHeadingStyle { get; set; } = PredefinedStyles.Heading;
+
+    /// <summary>
     /// Default style for hyperlinks
     /// </summary>
     /// <value>Hyperlink</value>


### PR DESCRIPTION
Hi!

At the company I work for, we use Word templates which contain normal headings (e.g. `Heading 1`, etc.) and numbered headings (e.g. `NumberedHeading 1` etc.).

This doesn't play nice with the current implementation of numbered headings in html2openxml. If you define a numbered heading within Word, you shouldn't add the numbering properties to the heading as this will mess up the style of the heading (spacings etc.).

This PR adds a new `NumberedHeadingStyle` to the `DefaultStyles`. If the `NumberedHeadingStyle` is defined differently by the user than `HeadingStyle`, this PR will not add a numbering property to the heading, keeping the numbered heading styling intact.

This implementation ensures that current implementations keep working as-is, while opening up the styling for alternative use-cases (such as ours).