### PR TITLE
Implement ImageProcessingMode which dictates how images should be handled during conversion

### DIFF
--- a/src/Html2OpenXml/Configuration enum.cs
+++ b/src/Html2OpenXml/Configuration enum.cs
@@ -47,3 +47,26 @@ public readonly struct QuoteChars(string begin, string end)
     internal string Prefix { get; } = begin;
     internal string Suffix { get; } = end;
 }
+
+/// <summary>
+/// Specifies how images should be processed during HTML to OpenXML conversion.
+/// </summary>
+public enum ImageProcessingMode
+{
+    /// <summary>
+    /// Downloads and embeds all images into the document (default behaviour).
+    /// This creates self-contained documents but may result in large file sizes.
+    /// </summary>
+    Embed = 0,
+    /// <summary>
+    /// Links to external images via external relationships instead of downloading them.
+    /// This keeps document size small but images won't display offline or if URLs become unavailable.
+    /// Data URI images (base64 encoded) are still embedded.
+    /// </summary>
+    LinkExternal = 1,
+    /// <summary>
+    /// Only embeds data URI images (base64 encoded inline images).
+    /// External images (http/https/file) are skipped entirely.
+    /// </summary>
+    EmbedDataUriOnly = 2,
+}

--- a/src/Html2OpenXml/Expressions/Image/ImageExpression.cs
+++ b/src/Html2OpenXml/Expressions/Image/ImageExpression.cs
@@ -94,6 +94,14 @@ class ImageExpression(IHtmlImageElement node) : ImageExpressionBase(node)
             preferredSize = ImageHeader.KeepAspectRatio(actualSize, preferredSize);
         }
 
+        // If size is still empty (e.g., for external linked images), use default dimensions
+        if (preferredSize.IsEmpty || preferredSize.Width <= 0 || preferredSize.Height <= 0)
+        {
+            // Use default size for external images or when size cannot be determined
+            // Default to a reasonable size (similar to how browsers handle images with unknown dimensions)
+            preferredSize = new Size(300, 200);
+        }
+
         long widthInEmus = new Unit(UnitMetric.Pixel, preferredSize.Width).ValueInEmus;
         long heightInEmus = new Unit(UnitMetric.Pixel, preferredSize.Height).ValueInEmus;
 
@@ -103,22 +111,26 @@ class ImageExpression(IHtmlImageElement node) : ImageExpressionBase(node)
                 new wp.Extent() { Cx = widthInEmus, Cy = heightInEmus },
                 new wp.EffectExtent() { LeftEdge = 19050L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L },
                 new wp.DocProperties() { Id = drawingObjId, Name = "Picture " + imageObjId, Description = string.Empty },
-                new wp.NonVisualGraphicFrameDrawingProperties {
+                new wp.NonVisualGraphicFrameDrawingProperties
+                {
                     GraphicFrameLocks = new a.GraphicFrameLocks() { NoChangeAspect = true }
                 },
                 new a.Graphic(
                     new a.GraphicData(
                         new pic.Picture(
-                            new pic.NonVisualPictureProperties {
-                                NonVisualDrawingProperties = new pic.NonVisualDrawingProperties() { 
+                            new pic.NonVisualPictureProperties
+                            {
+                                NonVisualDrawingProperties = new pic.NonVisualDrawingProperties()
+                                {
                                     Id = imageObjId,
                                     Name = DataUri.IsWellFormed(src) ? string.Empty : src,
-                                    Description = alt },
+                                    Description = alt
+                                },
                                 NonVisualPictureDrawingProperties = new pic.NonVisualPictureDrawingProperties(
                                     new a.PictureLocks() { NoChangeAspect = true, NoChangeArrowheads = true })
                             },
                             new pic.BlipFill(
-                                new a.Blip() { Embed = iinfo.ImagePartId },
+                                CreateBlip(iinfo, src),
                                 new a.SourceRectangle(),
                                 new a.Stretch(
                                     new a.FillRectangle())),
@@ -128,10 +140,14 @@ class ImageExpression(IHtmlImageElement node) : ImageExpressionBase(node)
                                     new a.Extents() { Cx = widthInEmus, Cy = heightInEmus }),
                                 new a.PresetGeometry(
                                     new a.AdjustValueList()
-                                ) { Preset = a.ShapeTypeValues.Rectangle }
-                            ) { BlackWhiteMode = a.BlackWhiteModeValues.Auto })
-                    ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" })
-            ) { DistanceFromTop = (UInt32Value) 0U, DistanceFromBottom = (UInt32Value) 0U, DistanceFromLeft = (UInt32Value) 0U, DistanceFromRight = (UInt32Value) 0U }
+                                )
+                                { Preset = a.ShapeTypeValues.Rectangle }
+                            )
+                            { BlackWhiteMode = a.BlackWhiteModeValues.Auto })
+                    )
+                    { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" })
+            )
+            { DistanceFromTop = (UInt32Value)0U, DistanceFromBottom = (UInt32Value)0U, DistanceFromLeft = (UInt32Value)0U, DistanceFromRight = (UInt32Value)0U }
         );
 
         return img;
@@ -147,11 +163,28 @@ class ImageExpression(IHtmlImageElement node) : ImageExpressionBase(node)
 
         if (unit.IsValid)
         {
-            return unit.Type == UnitMetric.Percent?
+            return unit.Type == UnitMetric.Percent ?
                 (int)(unit.Value * percentageBase / 100) :
                 unit.ValueInPx;
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Creates a Blip element with either an embedded or external image reference.
+    /// </summary>
+    private static a.Blip CreateBlip(HtmlImageInfo iinfo, string? src)
+    {
+        if (iinfo.IsExternal)
+        {
+            // Use Link property for external images
+            return new a.Blip() { Link = iinfo.ImagePartId };
+        }
+        else
+        {
+            // Use Embed property for embedded images (default behaviour)
+            return new a.Blip() { Embed = iinfo.ImagePartId };
+        }
     }
 }

--- a/src/Html2OpenXml/HtmlConverter.cs
+++ b/src/Html2OpenXml/HtmlConverter.cs
@@ -58,20 +58,20 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Parse some HTML content where the output is intented to be inserted in <see cref="MainDocumentPart"/>.
+    /// Parse some HTML content where the output is intended to be inserted in <see cref="MainDocumentPart"/>.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <returns>Returns a list of parsed paragraph.</returns>
     public IList<OpenXmlCompositeElement> Parse(string html)
     {
-        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester);
+        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester, ImageProcessing);
         return ParseCoreAsync(html, mainPart, bodyImageLoader,
             new ParallelOptions() { CancellationToken = CancellationToken.None })
             .ConfigureAwait(false).GetAwaiter().GetResult().ToList();
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing where the output is intented to be inserted in <see cref="MainDocumentPart"/>.
+    /// Start the asynchronous parse processing where the output is intended to be inserted in <see cref="MainDocumentPart"/>.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -84,7 +84,7 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing where the output is intented to be inserted in <see cref="MainDocumentPart"/>.
+    /// Start the asynchronous parse processing where the output is intended to be inserted in <see cref="MainDocumentPart"/>.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -95,20 +95,20 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing where the output is intented to be inserted in <see cref="MainDocumentPart"/>.
+    /// Start the asynchronous parse processing where the output is intended to be inserted in <see cref="MainDocumentPart"/>.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="parallelOptions">The configuration of parallelism while downloading the remote resources.</param>
     /// <returns>Returns a list of parsed paragraph.</returns>
     public Task<IEnumerable<OpenXmlCompositeElement>> ParseAsync(string html, ParallelOptions parallelOptions)
     {
-        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester);
+        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester, ImageProcessing);
 
         return ParseCoreAsync(html, mainPart, bodyImageLoader, parallelOptions);
     }
 
     /// <summary>
-    /// Parse asynchroneously the Html and append the output into the Header of the document.
+    /// Parse asynchronously the Html and append the output into the Header of the document.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="headerType">Determines the page(s) on which the current header shall be displayed.
@@ -122,7 +122,7 @@ public partial class HtmlConverter
         var headerPart = ResolveHeaderFooterPart<HeaderReference, HeaderPart>(headerType);
 
         headerPart.Header ??= new();
-        headerImageLoader ??= new ImagePrefetcher<HeaderPart>(headerPart, webRequester);
+        headerImageLoader ??= new ImagePrefetcher<HeaderPart>(headerPart, webRequester, ImageProcessing);
 
         var paragraphs = await ParseCoreAsync(html, headerPart, headerImageLoader,
             new ParallelOptions() { CancellationToken = cancellationToken },
@@ -133,7 +133,7 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Parse asynchroneously the Html and append the output into the Footer of the document.
+    /// Parse asynchronously the Html and append the output into the Footer of the document.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="footerType">Determines the page(s) on which the current footer shall be displayed.
@@ -147,7 +147,7 @@ public partial class HtmlConverter
         var footerPart = ResolveHeaderFooterPart<FooterReference, FooterPart>(footerType);
 
         footerPart.Footer ??= new();
-        footerImageLoader ??= new ImagePrefetcher<FooterPart>(footerPart, webRequester);
+        footerImageLoader ??= new ImagePrefetcher<FooterPart>(footerPart, webRequester, ImageProcessing);
 
         var paragraphs = await ParseCoreAsync(html, footerPart, footerImageLoader,
             new ParallelOptions() { CancellationToken = cancellationToken },
@@ -158,14 +158,14 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Parse asynchroneously the Html and append the output into the Body of the document.
+    /// Parse asynchronously the Html and append the output into the Body of the document.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <seealso cref="MainDocumentPart"/>
     public async Task ParseBody(string html, CancellationToken cancellationToken = default)
     {
-        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester);
+        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester, ImageProcessing);
         var paragraphs = await ParseCoreAsync(html, mainPart, bodyImageLoader,
             new ParallelOptions() { CancellationToken = cancellationToken },
             htmlStyles.GetParagraphStyle(htmlStyles.DefaultStyles.Paragraph))
@@ -201,7 +201,7 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing. Use this overload if you want to control the downloading of images.
+    /// Start the asynchronous parse processing. Use this overload if you want to control the downloading of images.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="parallelOptions">The configuration of parallelism while downloading the remote resources.</param>
@@ -210,13 +210,13 @@ public partial class HtmlConverter
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public Task<IEnumerable<OpenXmlCompositeElement>> Parse(string html, ParallelOptions parallelOptions)
     {
-        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester);
+        bodyImageLoader ??= new ImagePrefetcher<MainDocumentPart>(mainPart, webRequester, ImageProcessing);
 
         return ParseCoreAsync(html, mainPart, bodyImageLoader, parallelOptions);
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing and append the output into the Body of the document.
+    /// Start the asynchronous parse processing and append the output into the Body of the document.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -236,7 +236,7 @@ public partial class HtmlConverter
     }
 
     /// <summary>
-    /// Start the asynchroneous parse processing. Use this overload if you want to control the downloading of images.
+    /// Start the asynchronous parse processing. Use this overload if you want to control the downloading of images.
     /// </summary>
     /// <param name="html">The HTML content to parse</param>
     /// <param name="hostingPart">The OpenXml container where the content will be inserted into.</param>
@@ -393,6 +393,26 @@ public partial class HtmlConverter
     /// </summary>
     /// <remarks>The table will contains only one cell.</remarks>
     public bool RenderPreAsTable { get; set; }
+
+    /// <summary>
+    /// Gets or sets how images should be processed during conversion.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use <see cref="ImageProcessingMode.Embed"/> (default) to download and embed all images,
+    /// creating self-contained documents but potentially large file sizes.
+    /// </para>
+    /// <para>
+    /// Use <see cref="ImageProcessingMode.LinkExternal"/> to link to external images via relationships,
+    /// keeping document size small but requiring internet access to view images.
+    /// Data URI images (base64 encoded) are still embedded.
+    /// </para>
+    /// <para>
+    /// Use <see cref="ImageProcessingMode.EmbedDataUriOnly"/> to only embed data URI images
+    /// and skip external images entirely.
+    /// </para>
+    /// </remarks>
+    public ImageProcessingMode ImageProcessing { get; set; } = ImageProcessingMode.Embed;
 
     /// <summary>
     /// Defines whether ordered lists (<c>ol</c>) continue incrementing existing numbering

--- a/src/Html2OpenXml/Primitives/HtmlImageInfo.cs
+++ b/src/Html2OpenXml/Primitives/HtmlImageInfo.cs
@@ -37,6 +37,12 @@ sealed class HtmlImageInfo(string source, string partId)
     /// Gets the content type of the image.
     /// </summary>
     public PartTypeInfo TypeInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this image is linked externally rather than embedded.
+    /// When true, <see cref="ImagePartId"/> contains an external relationship ID instead of an embedded image part ID.
+    /// </summary>
+    public bool IsExternal { get; set; }
 }
 
 /// <summary>

--- a/test/HtmlToOpenXml.Tests/ImgTests.cs
+++ b/test/HtmlToOpenXml.Tests/ImgTests.cs
@@ -290,7 +290,168 @@ namespace HtmlToOpenXml.Tests
             Assert.That(runs.Select(r => r.GetFirstChild<Drawing>()), Has.All.Not.Null);
         }
 
-        private static (Drawing, ImagePart) AssertIsImg (OpenXmlPartContainer container, OpenXmlElement paragraph)
+        [Test]
+        public async Task ExternalLinkMode_RemoteImage_ShouldCreateExternalRelationship()
+        {
+            // Arrange
+            var mockHttp = new MockHttpMessageHandler(uri => Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StreamContent(ResourceHelper.GetStream("Resources.smiley.gif"))
+                {
+                    Headers = { { "Content-Type", "image/gif" } }
+                }
+            }));
+
+            var webRequest = new IO.DefaultWebRequest(new HttpClient(mockHttp));
+            converter = new HtmlConverter(mainPart, webRequest)
+            {
+                ImageProcessing = ImageProcessingMode.LinkExternal
+            };
+
+            // Act
+            await converter.ParseBody(
+                @"<img src='https://www.example.com/image.gif' width='42' height='42'>",
+                TestContext.CurrentContext.CancellationToken);
+
+            // Assert
+            var paragraphs = mainPart.Document.Body!.Elements<Paragraph>();
+            Assert.That(paragraphs.Count(), Is.EqualTo(1));
+
+            var run = paragraphs.First().GetFirstChild<Run>();
+            Assert.That(run, Is.Not.Null);
+            var drawing = run.GetFirstChild<Drawing>();
+            Assert.That(drawing, Is.Not.Null);
+
+            var pic = drawing.Inline?.Graphic?.GraphicData?.GetFirstChild<pic.Picture>();
+            Assert.That(pic?.BlipFill?.Blip, Is.Not.Null);
+
+            // Verify it's using Link instead of Embed
+            Assert.That(pic.BlipFill.Blip.Link, Is.Not.Null);
+            Assert.That(pic.BlipFill.Blip.Embed, Is.Null);
+
+            // Verify external relationship was created
+            var externalRels = mainPart.ExternalRelationships
+                .Where(r => r.RelationshipType == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image");
+            Assert.That(externalRels.Count(), Is.EqualTo(1));
+            Assert.That(externalRels.First().Uri.ToString(), Is.EqualTo("https://www.example.com/image.gif"));
+
+            // Verify no image parts were created
+            Assert.That(mainPart.ImageParts.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExternalLinkMode_DataUri_ShouldStillEmbed()
+        {
+            // Arrange
+            converter = new HtmlConverter(mainPart)
+            {
+                ImageProcessing = ImageProcessingMode.LinkExternal
+            };
+
+            // Act
+            await converter.ParseBody(
+                @"<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==' width='42' height='42'>",
+                TestContext.CurrentContext.CancellationToken);
+
+            // Assert
+            var paragraphs = mainPart.Document.Body!.Elements<Paragraph>();
+            Assert.That(paragraphs.Count(), Is.EqualTo(1));
+
+            var run = paragraphs.First().GetFirstChild<Run>();
+            var drawing = run?.GetFirstChild<Drawing>();
+            var pic = drawing?.Inline?.Graphic?.GraphicData?.GetFirstChild<pic.Picture>();
+
+            // Data URIs should still be embedded
+            Assert.That(pic?.BlipFill?.Blip?.Embed, Is.Not.Null);
+            Assert.That(pic?.BlipFill?.Blip?.Link, Is.Null);
+            Assert.That(mainPart.ImageParts.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task EmbedDataUriOnlyMode_RemoteImage_ShouldBeSkipped()
+        {
+            // Arrange
+            var mockHttp = new MockHttpMessageHandler(uri => Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StreamContent(ResourceHelper.GetStream("Resources.smiley.gif"))
+                {
+                    Headers = { { "Content-Type", "image/gif" } }
+                }
+            }));
+
+            var webRequest = new IO.DefaultWebRequest(new HttpClient(mockHttp));
+            converter = new HtmlConverter(mainPart, webRequest)
+            {
+                ImageProcessing = ImageProcessingMode.EmbedDataUriOnly
+            };
+
+            // Act
+            await converter.ParseBody(
+                @"<img src='https://www.example.com/image.gif' width='42' height='42'>",
+                TestContext.CurrentContext.CancellationToken);
+
+            // Assert
+            var paragraphs = mainPart.Document.Body!.Elements<Paragraph>();
+            // Image should be skipped, so paragraph should be empty or not contain drawing
+            Assert.That(paragraphs.Count(), Is.EqualTo(0));
+            Assert.That(mainPart.ImageParts.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task EmbedDataUriOnlyMode_DataUri_ShouldEmbed()
+        {
+            // Arrange
+            converter = new HtmlConverter(mainPart)
+            {
+                ImageProcessing = ImageProcessingMode.EmbedDataUriOnly
+            };
+
+            // Act
+            await converter.ParseBody(
+                @"<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==' width='42' height='42'>",
+                TestContext.CurrentContext.CancellationToken);
+
+            // Assert
+            var paragraphs = mainPart.Document.Body!.Elements<Paragraph>();
+            Assert.That(paragraphs.Count(), Is.EqualTo(1));
+            AssertIsImg(mainPart, paragraphs.First());
+            Assert.That(mainPart.ImageParts.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task EmbedMode_RemoteImage_ShouldDownloadAndEmbed()
+        {
+            // Arrange
+            var mockHttp = new MockHttpMessageHandler(uri => Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StreamContent(ResourceHelper.GetStream("Resources.smiley.gif"))
+                {
+                    Headers = { { "Content-Type", "image/gif" } }
+                }
+            }));
+
+            var webRequest = new IO.DefaultWebRequest(new HttpClient(mockHttp));
+            converter = new HtmlConverter(mainPart, webRequest)
+            {
+                ImageProcessing = ImageProcessingMode.Embed // Default behavior
+            };
+
+            // Act
+            await converter.ParseBody(
+                @"<img src='https://www.example.com/image.gif' width='42' height='42'>",
+                TestContext.CurrentContext.CancellationToken);
+
+            // Assert
+            var paragraphs = mainPart.Document.Body!.Elements<Paragraph>();
+            Assert.That(paragraphs.Count(), Is.EqualTo(1));
+            AssertIsImg(mainPart, paragraphs.First());
+            Assert.That(mainPart.ImageParts.Count(), Is.EqualTo(1));
+        }
+
+        private static (Drawing, ImagePart) AssertIsImg(OpenXmlPartContainer container, OpenXmlElement paragraph)
         {
             var run = paragraph.GetFirstChild<Run>();
             Assert.That(run, Is.Not.Null);


### PR DESCRIPTION
Hello

The idea of this PR is to provide a working example of being able to dictate how HtmlToOpenXml should handle images.

This is done by overriding `ImageProcessing` in the HtmlConverter constructor thus:

    HtmlConverter htmlConverter = new(mainPart, new DefaultWebRequest())
    {
        // Default value of ImageProcessingMode is ImageProcessingMode.Embed (the current behaviour).
        ImageProcessing = ImageProcessingMode.LinkExternal
    };

I've also provided handling for data uris but my primary focus here has been to swap external images out so that they use `Blip.Link` instead of `Blip.Embed`. As stated above, the default behaviour remains the same (e.g. ImageProcessing.Embed) unless explicitly overridden.

Example implementation - taken from a modified form of examples\Demo\Program.cs

    string inputFile = "C:\\ConvertedHtml.html";
    string htmlContent = await File.ReadAllTextAsync(inputFile);

    string outputPath = "C:\\ConvertedHtml.docx";
    using WordprocessingDocument wordDoc = WordprocessingDocument.Create(outputPath, WordprocessingDocumentType.Document);
    MainDocumentPart mainPart = wordDoc.AddMainDocumentPart();
    mainPart.Document = new Document(new DocumentFormat.OpenXml.Wordprocessing.Body());

    HtmlConverter htmlConverter = new(mainPart, new DefaultWebRequest())
    {
        ImageProcessing = ImageProcessingMode.LinkExternal
    };

    await htmlConverter.ParseBody(htmlContent);

    AssertThatOpenXmlDocumentIsValid(wordDoc);

    mainPart.Document.Save();

During my tests, I have found that a Word document with 30 embedded external images has been reduced from 4MB to 10KB, so there is a sizeable reduction.

Further changes could be made later, for example providing additional rules for dictating which domains should/shouldn't be embedded, or perhaps providing a mechanism for HTML-level customisation of image processing (for example by use of an attribute such as `<img src="..." data-imageProcessing="Embed" />`

I also added 5 new unit tests (in ImgTests.cs) to support my changes and made some highlighted spelling corrections to some usages of `asynchronous` and `intended`. My apologies if some changes to formatting occurred. I use ReSharper and my Visual Studio formats the documents such as braces, imports, access modifiers, etc, and I've done my best to discard those changes in my PR.

Kind regards
Dan Atkinson - Atcore Technology Ltd