### PR TITLE
[FIX] Greek numbering in ordered lists (upper-greek / lower-greek)

### DIFF
--- a/examples/Demo/Resources/CompleteRunTest.html
+++ b/examples/Demo/Resources/CompleteRunTest.html
@@ -154,6 +154,34 @@
         <li>Wine</li>
     </ol>
 
+    <p>An Ordered List with Greek numbering: </p>
+    <ol style="list-style-type: upper-greek">
+        <li>alpha</li>
+        <li>
+            beta
+            <ol style="list-style-type: lower-greek">
+                <li>two.one</li>
+                <li>two.two</li>
+                <li>two.three</li>
+            </ol>
+        </li>
+
+        <li>
+            three
+            <ol style="list-style-type: lower-greek">
+                <li>three.one</li>
+                <li>
+                    three.two
+                    <ol>
+                        <li>three.two.one</li>
+                        <li>three.two.two</li>
+                    </ol>
+                </li>
+            </ol>
+        </li>
+        <li>four</li>
+    </ol>
+
     <table border=1><tr><td>Inside table</td></tr></table>
     <hr />
     <p>delta parameter (<span style='font-family:Symbol'>d</span>)</p>

--- a/examples/Demo/Resources/NumberingList.htm
+++ b/examples/Demo/Resources/NumberingList.htm
@@ -78,3 +78,30 @@
     </li>
     <li>four</li>
 </ol>
+
+<ol style="list-style-type: upper-greek">
+    <li>one</li>
+    <li>
+        two
+        <ol style="list-style-type: lower-greek">
+            <li>two.one</li>
+            <li>two.two</li>
+            <li>two.three</li>
+        </ol>
+    </li>
+
+    <li>
+        three
+        <ol style="list-style-type: lower-greek">
+            <li>three.one</li>
+            <li>
+                three.two
+                <ol>
+                    <li>three.two.one</li>
+                    <li>three.two.two</li>
+                </ol>
+            </li>
+        </ol>
+    </li>
+    <li>four</li>
+</ol>

--- a/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
@@ -40,6 +40,7 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
     private static readonly HashSet<string> supportedListTypes = 
         ["disc", "decimal", "square", "circle",
          "lower-alpha", "upper-alpha", "lower-latin", "upper-latin",
+         "lower-greek", "upper-greek",
          "lower-roman", "upper-roman",
          "decimal-tiered" /* not W3C compliant */];
     private ParagraphStyleId? listParagraphStyleId;
@@ -243,6 +244,7 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
         "A" => "upper-alpha",
         "i" => "lower-roman",
         "I" => "upper-roman",
+        "lower-greek" or "upper-greek" => type,
         _ => null
     };
 

--- a/test/HtmlToOpenXml.Tests/NumberingTests.cs
+++ b/test/HtmlToOpenXml.Tests/NumberingTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Packaging;
 
@@ -647,6 +647,58 @@ namespace HtmlToOpenXml.Tests
                 Assert.That(tableProperties.TableWidth.Type?.Value, Is.EqualTo(TableWidthUnitValues.Pct));
                 Assert.That(tableProperties.TableWidth.Width?.HasValue, Is.True);
                 Assert.That(Convert.ToInt32(tableProperties.TableWidth.Width.Value), Is.GreaterThan(0).And.LessThan(5000));
+            }
+        }
+
+        [Test]
+        public async Task LowerGreekList_ReturnsListWithGreekNumbering()
+        {
+            await converter.ParseBody(@"
+                <ol style='list-style-type: lower-greek'>
+                    <li>Item 1</li>
+                    <li>Item 2</li>
+                </ol>"
+            );
+
+            var elements = mainPart.Document!.Body!.Elements<Paragraph>().ToList();
+            Assert.That(elements, Has.Count.EqualTo(2));
+
+            var numbering = mainPart.NumberingDefinitionsPart!.Numbering!;
+            var absNum = numbering.Elements<AbstractNum>().SingleOrDefault();
+
+            Assert.That(absNum, Is.Not.Null);
+            Assert.That(absNum.AbstractNumDefinitionName?.Val?.Value, Is.EqualTo("lower-greek"));
+
+            var level = absNum.Elements<Level>().First();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(level.NumberingFormat?.Val?.Value, Is.EqualTo(NumberFormatValues.LowerLetter));
+                Assert.That(level.LevelText?.Val?.Value, Is.EqualTo("%1."));
+            }
+        }
+
+        [Test]
+        public async Task UpperGreekList_ReturnsListWithGreekNumbering()
+        {
+            await converter.ParseBody(@"
+                <ol style='list-style-type: upper-greek'>
+                    <li>Item 1</li>
+                </ol>"
+            );
+
+            var numbering = mainPart.NumberingDefinitionsPart!.Numbering!;
+            var absNum = numbering.Elements<AbstractNum>().SingleOrDefault();
+
+            Assert.That(absNum, Is.Not.Null);
+            Assert.That(absNum.AbstractNumDefinitionName?.Val?.Value, Is.EqualTo("upper-greek"));
+
+            var level = absNum.Elements<Level>().First();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(level.NumberingFormat?.Val?.Value, Is.EqualTo(NumberFormatValues.UpperLetter));
+                Assert.That(level.LevelText?.Val?.Value,  Is.EqualTo("%1."));
             }
         }
     }


### PR DESCRIPTION
1. Updated supportedListTypes Hashset to include "upper-greel" and "lower-greek"
2. Add "lower-greek" and "upper-greek" in ListTypeToListStyleType() method switch expression