### PR TITLE
Add support for custom bullet symbols

### DIFF
--- a/examples/Demo/Program.cs
+++ b/examples/Demo/Program.cs
@@ -12,7 +12,7 @@ namespace Demo
         static async Task Main(string[] args)
         {
             const string filename = "test.docx";
-            string html = ResourceHelper.GetString("Resources.CompleteRunTest.html");
+            string html = ResourceHelper.GetString("Resources.UlStyles.html");
             if (File.Exists(filename)) File.Delete(filename);
 
             using (MemoryStream generatedDocument = new())

--- a/examples/Demo/Resources/UlStyles.html
+++ b/examples/Demo/Resources/UlStyles.html
@@ -1,0 +1,31 @@
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+<ul style="list-style-type: '-';">
+    <li style="text-align: justify;">test 2</li>
+    <li style="text-align: justify;">test 3</li>
+    <li style="text-align: justify;">&nbsp;</li>
+</ul>
+<p style="text-align: justify;">&nbsp;</p>
+<ul style="list-style-type: 'disc';">
+    <li style="text-align: justify;">test 2</li>
+    <li style="text-align: justify;">test 3</li>
+    <li style="text-align: justify;">&nbsp;</li>
+</ul>
+<p style="text-align: justify;">&nbsp;</p>
+<ul style="list-style-type: '-';">
+    <li style="text-align: justify;">test 2</li>
+    <li style="text-align: justify;">test 3</li>
+    <li style="text-align: justify;">&nbsp;</li>
+</ul>
+<p style="text-align: justify;">&nbsp;</p>
+<ul style="list-style-type: '😀';">
+    <li style="text-align: justify;">test 2</li>
+    <li style="text-align: justify;">test 3</li>
+    <li style="text-align: justify;">&nbsp;</li>
+</ul>
+</body>
+</html>

--- a/examples/Demo/Resources/UlStyles.html
+++ b/examples/Demo/Resources/UlStyles.html
@@ -10,7 +10,7 @@
     <li style="text-align: justify;">&nbsp;</li>
 </ul>
 <p style="text-align: justify;">&nbsp;</p>
-<ul style="list-style-type: 'disc';">
+<ul style="list-style-type: disc;">
     <li style="text-align: justify;">test 2</li>
     <li style="text-align: justify;">test 3</li>
     <li style="text-align: justify;">&nbsp;</li>
@@ -23,6 +23,13 @@
 </ul>
 <p style="text-align: justify;">&nbsp;</p>
 <ul style="list-style-type: '😀';">
+    <li style="text-align: justify;">test 2</li>
+    <li style="text-align: justify;">test 3</li>
+    <li style="text-align: justify;">&nbsp;</li>
+</ul>
+
+<p style="text-align: justify;">&nbsp;</p>
+<ul style="list-style-type: dash;">
     <li style="text-align: justify;">test 2</li>
     <li style="text-align: justify;">test 3</li>
     <li style="text-align: justify;">&nbsp;</li>

--- a/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
@@ -38,7 +38,7 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
     // https://answers.microsoft.com/en-us/msoffice/forum/all/custom-list-number-style/21a54399-4404-4c37-8843-2ccaaf827485
     // Image bullet: http://officeopenxml.com/WPnumbering-imagesAsSymbol.php
     private static readonly HashSet<string> supportedListTypes = 
-        ["disc", "decimal", "square", "circle",
+        ["disc", "decimal", "square", "circle", "dash",
          "lower-alpha", "upper-alpha", "lower-latin", "upper-latin",
          "lower-greek", "upper-greek",
          "lower-roman", "upper-roman",

--- a/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/ListExpression.cs
@@ -227,7 +227,15 @@ sealed class ListExpression(IHtmlElement node) : NumberingExpressionBase(node)
             if (parentName != null && IsCascadingStyle(parentName))
                 return parentName!;
 
-            type = orderedList? "decimal" : "disc";
+            // If a specific list-style-type is provided for an unordered list (e.g., a custom string like "'-'"),
+            // we strip the surrounding quotes to extract the raw symbol.
+            // Otherwise, we fallback to the default "decimal" or "disc" styles.
+            if (!orderedList && !string.IsNullOrEmpty(type))
+            {
+                return type!.Trim('\'', '\"');
+            }
+            
+            return orderedList ? "decimal" : "disc";
         }
 
         return type!;

--- a/src/Html2OpenXml/Expressions/Numbering/NumberingExpressionBase.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/NumberingExpressionBase.cs
@@ -50,8 +50,20 @@ abstract class NumberingExpressionBase(IHtmlElement node) : BlockElementExpressi
 
         Numbering numberingPart = context.MainPart.NumberingDefinitionsPart!.Numbering!;
 
+        AbstractNum abstractNum;
+        
         // at this stage, we have sanitized the list style so it's safe to grab them from the predefined template lists
-        var abstractNum =  predefinedNumberingLists[listName];
+        if (predefinedNumberingLists.TryGetValue(listName, out var predefined))
+        {
+            // If it's a predefined style, we clone it as usual
+            abstractNum = (AbstractNum)predefined.CloneNode(true);
+        }
+        else
+        {
+            // If not found in predefined lists, listName contains a custom bullet character (e.g., "-")
+            abstractNum = CreateCustomBulletAbstractNum(listName);
+        }
+        
         abstractNum = (AbstractNum) abstractNum.CloneNode(true);
         abstractNum.AbstractNumberId = IncrementAbstractNumId(context, numberingPart);
         var level1 = abstractNum.GetFirstChild<Level>()!;
@@ -216,6 +228,38 @@ abstract class NumberingExpressionBase(IHtmlElement node) : BlockElementExpressi
         isInitialized = true;
     }
 
+    /// <summary>
+    /// Generates a custom abstract numbering definition for unordered lists using a specific symbol.
+    /// </summary>
+    /// <param name="customSymbol">The custom character or string to be used as the list bullet.</param>
+    /// <returns>An <see cref="AbstractNum"/> instance configured with the custom bullet symbol across all levels.</returns>
+    private AbstractNum CreateCustomBulletAbstractNum(string customSymbol)
+    {
+        var abstractNum = new AbstractNum {
+            AbstractNumDefinitionName = new() { Val = customSymbol },
+            MultiLevelType = new() { Val = MultiLevelValues.HybridMultilevel }
+        };
+        
+        for (var lvlIndex = 0; lvlIndex <= MaxLevel; lvlIndex++)
+        {
+            abstractNum.Append(new Level {
+                StartNumberingValue = new() { Val = 1 },
+                NumberingFormat = new() { Val = NumberFormatValues.Bullet },
+                LevelIndex = lvlIndex,
+                LevelText = new() { Val = string.Format(customSymbol, lvlIndex+1) },
+                LevelJustification = new() { Val = LevelJustificationValues.Left },
+                PreviousParagraphProperties = new() {
+                    Indentation = new() {
+                        Left = ((lvlIndex + 1) * Indentation * 2).ToString(),
+                        Hanging = Indentation.ToString()
+                    }
+                }
+            });
+        }
+
+        return abstractNum;
+    }
+    
     /// <summary>
     /// Predefined template of lists.
     /// </summary>

--- a/src/Html2OpenXml/Expressions/Numbering/NumberingExpressionBase.cs
+++ b/src/Html2OpenXml/Expressions/Numbering/NumberingExpressionBase.cs
@@ -274,6 +274,7 @@ abstract class NumberingExpressionBase(IHtmlElement node) : BlockElementExpressi
             ("disc", NumberFormatValues.Bullet, "•"),
             ("square", NumberFormatValues.Bullet, "▪"),
             ("circle", NumberFormatValues.Bullet, "o"),
+            ("dash", NumberFormatValues.Bullet, "-"),
             ("upper-alpha", NumberFormatValues.UpperLetter, "%{0}."),
             ("lower-alpha", NumberFormatValues.LowerLetter, "%{0}."),
             ("upper-roman", NumberFormatValues.UpperRoman, "%{0}."),


### PR DESCRIPTION
Hi! First of all, thank you for the great library

I recently encountered a need to support dashed lists (`<ul style="list-style-type: '-';">`), which are not natively supported by the predefined templates. I've implemented a feature to generate custom bullets on the fly so this functionality can be available for everyone in future releases.

### What was changed:
1. **Refactored `GetListName`**: Streamlined the method to extract raw custom symbols (stripping single/double quotes) from the CSS property if the type is not found in `supportedListTypes`.
2. **Dynamic `AbstractNum` Generation**: Added `CreateCustomBulletAbstractNum` to dynamically generate an `AbstractNum` template configured with the custom symbol across all list levels (0 to `MaxLevel`).
3. **Updated `GetOrCreateListTemplate`**: Intercepted the custom string. If the list style isn't in `predefinedNumberingLists`, it safely generates the new custom template on the fly and caches it in `knownAbsNumIds` to prevent duplication.

**Example:**
Html
[UlStyles.html](https://github.com/user-attachments/files/28287699/UlStyles.html)

Old result
[test_old.docx](https://github.com/user-attachments/files/28287715/test_old.docx)
<img width="824" height="551" alt="image" src="https://github.com/user-attachments/assets/74a17351-8e82-4ad4-af52-5295874e2642" />


New result
[test_New.docx](https://github.com/user-attachments/files/28287721/test_New.docx)
<img width="788" height="570" alt="image" src="https://github.com/user-attachments/assets/afc66c33-74ed-46e9-8350-ffa314ff5ac9" />

